### PR TITLE
cn0326: made to calibrate before every data read and fixed two bugs

### DIFF
--- a/projects/ADuCM3029_demo_cn0326/include/AD7793.h
+++ b/projects/ADuCM3029_demo_cn0326/include/AD7793.h
@@ -71,7 +71,7 @@ void AD7793_WriteRegister( uint8_t ui8address, uint32_t ui32data);
 void AD7793_SelectChannel(uint8_t ui8channel);
 uint32_t AD7793_Scan(enMode mode,  uint8_t channel);
 void AD7793_Calibrate(uint8_t ui8channel, enMode mode);
-int32_t AD7793_ConvertToVolts(uint32_t u32adcValue);
+float AD7793_ConvertToVolts(uint32_t u32adcValue);
 
 /****************************** Internal defines ******************************/
 

--- a/projects/ADuCM3029_demo_cn0326/src/AD7793.c
+++ b/projects/ADuCM3029_demo_cn0326/src/AD7793.c
@@ -155,10 +155,7 @@ uint32_t AD7793_Scan(enMode mode,  uint8_t ui8channel)
 {
 	static  uint32_t ui32result, ui32reg_value;
 
-	/* Set value (read command + DATA register address) to write in COMM
-	 * register */
-	uint8_t ui8reg_adrr = (AD7793_COMM_READ
-	                       | AD7793_COMM_ADR(AD7793_REG_DATA));
+	AD7793_Calibrate(ui8channel, CAL_INT_FULL_MODE);
 
 	/* Select channel to scan */
 	AD7793_SelectChannel(ui8channel);
@@ -177,14 +174,13 @@ uint32_t AD7793_Scan(enMode mode,  uint8_t ui8channel)
 		AD7793_WriteRegister(AD7793_REG_MODE, ui32reg_value);
 	}
 
-	if(mode == CONTINUOUS_CONV)
+	if(mode == CONTINUOUS_CONV) {
 		//DioClr(CS_PORT, CS_PIN);
+	}
 
-		while ((AD7793_ReadRegister(AD7793_REG_STAT)& RDY_BIT) != RDY_BIT);
+	while ((AD7793_ReadRegister(AD7793_REG_STAT)& RDY_BIT) == RDY_BIT);
 
-	SPI_Write(0xAA, 0xAAAA, 2);
-
-	ui32result =  SPI_Read(ui8reg_adrr,  reg_size[AD7793_REG_DATA]);
+	ui32result = AD7793_ReadRegister(AD7793_REG_DATA);
 
 	//DioSet(CS_PORT, CS_PIN);
 
@@ -241,7 +237,7 @@ void AD7793_Calibrate(uint8_t ui8channel, enMode mode)
 	AD7793_WriteRegister(AD7793_REG_MODE, ui32reg_value);
 
 	/* Wait until RDY bit from STATUS register is high */
-	while ((AD7793_ReadRegister(AD7793_REG_STAT)& RDY_BIT) != RDY_BIT);
+	while ((AD7793_ReadRegister(AD7793_REG_STAT)& RDY_BIT) == RDY_BIT);
 
 	//DioSet(CS_PORT, CS_PIN); todo: asses the importance of the gpio functions
 }
@@ -254,13 +250,13 @@ void AD7793_Calibrate(uint8_t ui8channel, enMode mode)
 
    @return int32_t - converted voltage
 **/
-int32_t AD7793_ConvertToVolts(uint32_t u32adcValue)
+float AD7793_ConvertToVolts(uint32_t u32adcValue)
 {
-	int32_t i32voltage;
+	float f32voltage;
 
 	/* Vref = 1170 [mV]    */        /* Calculate voltage */
-	i32voltage = ((int64_t)(u32adcValue - 0x800000) * 1170) / (int32_t)0x800000;
+	f32voltage = ((float)(u32adcValue - 0x800000) * 1170) / (float)0x800000;
 
-	return i32voltage;
+	return f32voltage;
 }
 

--- a/projects/ADuCM3029_demo_cn0326/src/CN0326.c
+++ b/projects/ADuCM3029_demo_cn0326/src/CN0326.c
@@ -112,7 +112,7 @@ void CN0326_Init(void)
 #if(USE_IOUT2 == YES)
 	ui32result = AD7793_Scan(SINGLE_CONV, AD7793_CH_AIN3P_AIN3M);
 	i32voltage = AD7793_ConvertToVolts(ui32result);
-	iout2_calibration = u32voltage / (float)5000;
+	iout2_calibration = i32voltage / (float)5000;
 #endif
 }
 
@@ -123,9 +123,8 @@ void CN0326_Init(void)
 **/
 float CN0326_CalculateTemp(void)
 {
-	static float temp, res, f32current;
+	static float temp, res, f32current, f32voltage;
 	uint32_t ui32adcValue;
-	int32_t i32voltage;
 
 	/* Check which excitation current to use */
 #if(USE_IOUT2 == YES)
@@ -137,10 +136,10 @@ float CN0326_CalculateTemp(void)
 	ui32adcValue = AD7793_Scan(SINGLE_CONV, AD7793_CH_AIN2P_AIN2M);
 
 	/* Convert ADC output value to voltage */
-	i32voltage = AD7793_ConvertToVolts(ui32adcValue);
+	f32voltage = AD7793_ConvertToVolts(ui32adcValue);
 
 	/* Calculate RTD resistance */
-	res = i32voltage / (float)f32current;
+	res = f32voltage / (float)f32current;
 
 	/* Calculate temperature value */
 	temp = ((res - RMIN) / (TEMP_COEFF * RMIN));


### PR DESCRIPTION
To work properly, the sensor has to be calibrated before every data
aquisition. The first bug was the wait condition in the scan method where
the program was waiting for convertion to finish only in continuous
convertion mode. The second bus was that the wait condition for the
convertion was wrong. These changes address these issues.

Signed-off-by: adrimbarean <Andrei.Drimbarean@analog.com>