### PR TITLE
.gitignore: Update with Debug and Release folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@
 # Debug files
 *.dSYM/
 *.su
+
+# Debug and Release folder
+Debug/
+Release/


### PR DESCRIPTION
This commit will ensure that no files from Debug and Release folder will be
uploaded to github. We will use this for all ADICUP projects and will
ensure consistency across platforms. This folders will be automatically
generated once the user builds his project.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>