### PR TITLE
cmsis-packs: release: Fix pdsc urls

### DIFF
--- a/cmsis-packs/releases/ble/AnalogDevices.ADI-BleSoftware.pdsc
+++ b/cmsis-packs/releases/ble/AnalogDevices.ADI-BleSoftware.pdsc
@@ -4,7 +4,7 @@
     <vendor>AnalogDevices</vendor>
     <name>ADI-BleSoftware</name>
     <description>Analog Devices Bluetooth Low Energy Software</description>
-    <url>https://github.com/analogdevicesinc/EVAL-ADICUP3029/tree/master/cmsis-packs/releases/ble</url>
+    <url>https://github.com/analogdevicesinc/EVAL-ADICUP3029/raw/master/cmsis-packs/releases/ble</url>
     <supportContact>http://www.analog.com/en/support/technical-support.html</supportContact>
     <license>License/license_ble.txt</license>
 

--- a/cmsis-packs/releases/wifi/AnalogDevices.ADI-WifiSoftware.pdsc
+++ b/cmsis-packs/releases/wifi/AnalogDevices.ADI-WifiSoftware.pdsc
@@ -4,7 +4,7 @@
     <vendor>AnalogDevices</vendor>
     <name>ADI-WifiSoftware</name>
     <description>Analog Devices WiFi Software</description>
-    <url>https://github.com/analogdevicesinc/EVAL-ADICUP3029/tree/master/cmsis-packs/releases/wifi</url>
+    <url>https://github.com/analogdevicesinc/EVAL-ADICUP3029/raw/master/cmsis-packs/releases/wifi</url>
     <supportContact>http://www.analog.com/en/support/technical-support.html</supportContact>
     <license>License/2017-07-27-LWSCEDL Click Thru SLA.txt</license>
 


### PR DESCRIPTION
The url must point to the raw repository link not the master. This patch
fixes that issue.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>