### PR TITLE
Cn 0435 scripts

### DIFF
--- a/projects/ADuCM3029_demo_cn0435/Scripts/Basic MODBUS Examples/read_adc_analog_input_registers.py
+++ b/projects/ADuCM3029_demo_cn0435/Scripts/Basic MODBUS Examples/read_adc_analog_input_registers.py
@@ -1,0 +1,13 @@
+"""Read analog input registers to determine ADC channels code."""
+
+import minimalmodbus
+
+# declare an instrument object with port name, slave address as input arguments
+INSTRUMENT = minimalmodbus.Instrument('COM12', 1)
+
+# read 16 registers starting from address 12549 by using function code 4
+ADC_CHANNELS_CODES = INSTRUMENT.read_registers(
+    registeraddress=12549, numberOfRegisters=16, functioncode=4)
+
+# result a list with 16 elements in decimal format
+print(ADC_CHANNELS_CODES)

--- a/projects/ADuCM3029_demo_cn0435/Scripts/Basic MODBUS Examples/read_common_analog_input_registers.py
+++ b/projects/ADuCM3029_demo_cn0435/Scripts/Basic MODBUS Examples/read_common_analog_input_registers.py
@@ -1,0 +1,13 @@
+"""Read common analog input registers to determine PLC/DCS configuration."""
+
+import minimalmodbus
+
+# declare an instrument object with port name, slave address as input arguments
+INSTRUMENT = minimalmodbus.Instrument('COM12', 1)
+
+# read 5 registers starting from address 0 by using function code 4
+COMMON_ANALOG_INPUT_REGISTERS = INSTRUMENT.read_registers(
+    registeraddress=0, numberOfRegisters=5, functioncode=4)
+
+# result a list with 5 elements in decimal format
+print(COMMON_ANALOG_INPUT_REGISTERS)

--- a/projects/ADuCM3029_demo_cn0435/Scripts/Basic MODBUS Examples/set_adc_output_code.py
+++ b/projects/ADuCM3029_demo_cn0435/Scripts/Basic MODBUS Examples/set_adc_output_code.py
@@ -1,0 +1,23 @@
+"""Read and write one output holding register to change ADC output code."""
+
+import minimalmodbus
+
+# declare an instrument object with port name, slave address as input arguments
+INSTRUMENT = minimalmodbus.Instrument('COM12', 1)
+
+# read a single register from address 12544 by using function code 3
+INITIAL_ADC_OUTPUT_CODE = INSTRUMENT.read_register(
+    registeraddress=12544, functioncode=3)
+
+# result an integer
+print(INITIAL_ADC_OUTPUT_CODE)
+
+# wrie a single register from address 12544 by using function code 6
+INSTRUMENT.write_register(registeraddress=12544, value=1, functioncode=6)
+
+# read a single register from address 12544 by using function code 3
+FINAL_ADC_OUTPUT_CODE = INSTRUMENT.read_register(
+    registeraddress=12544, functioncode=3)
+
+# result an integer
+print(FINAL_ADC_OUTPUT_CODE)

--- a/projects/ADuCM3029_demo_cn0435/Scripts/Basic MODBUS Examples/set_dac_output_voltage.py
+++ b/projects/ADuCM3029_demo_cn0435/Scripts/Basic MODBUS Examples/set_dac_output_voltage.py
@@ -1,0 +1,23 @@
+"""Read and write one output holding register to change DAC channel voltage."""
+
+import minimalmodbus
+
+# declare an instrument object with port name, slave address as input arguments
+INSTRUMENT = minimalmodbus.Instrument('COM12', 1)
+
+# read a single register from address 4356 by using function code 3
+INITIAL_DAC_CHANNEL_1_CODE = INSTRUMENT.read_register(
+    registeraddress=4356, functioncode=3)
+
+# result an integer
+print(INITIAL_DAC_CHANNEL_1_CODE)
+
+# wrie a single register from address 4356 by using function code 6
+INSTRUMENT.write_register(registeraddress=4356, value=65535, functioncode=6)
+
+# read a single register from address 4356 by using function code 3
+FINAL_DAC_CHANNEL_1_CODE = INSTRUMENT.read_register(
+    registeraddress=4356, functioncode=3)
+
+# result an integer
+print(FINAL_DAC_CHANNEL_1_CODE)

--- a/projects/ADuCM3029_demo_cn0435/Scripts/dcs_cn0414_utilities.py
+++ b/projects/ADuCM3029_demo_cn0435/Scripts/dcs_cn0414_utilities.py
@@ -1,0 +1,634 @@
+"""Base MODBUS functions.
+
+This module provide base functionalities to easy interact with:
+CN0414 - Analog input and HART for PLC/DCS systems
+CN0418 - Analog output and HART for PLC/DCS systems
+CN0416 - RS485 transceiver.
+"""
+
+__version__ = '0.1'
+__author__ = 'Mihai Ionut Suciu'
+__status__ = 'Development'
+
+from time import sleep
+from colorama import init, Fore
+import dcs_cn0435_utilities as utilities
+
+init(autoreset=True)
+
+
+def read_analog_input_regs_cn0414(
+        global_data: dict, address: list,
+        registers_number: int = 50, debug: bool = False) -> list:
+    """Read analog input registers.
+
+    Read analog input registers from CN0414 with function code 4.
+
+    Args:
+        instrument: Instrument object created by minimalmodbus
+        delay: Delay between MODBUS commands
+        address: MODBUS register start address
+        registers_number: Number of MODBUS register read (default value = 50)
+        debug: If True will print registers description and value
+            in a colored table (default value = False)
+
+    Returns:
+        Return a list of registers values
+
+    """
+    register_address = utilities.generate_register_address(address)
+    sleep(global_data["DELAY"])
+    registers = global_data["INSTRUMENT"].read_registers(
+        register_address, registers_number, functioncode=4)
+
+    if debug:
+        print(Fore.LIGHTMAGENTA_EX + '\nAnalog input registers at',
+              Fore.YELLOW + 'MODBUS address ' + str(address[1]))
+        labels = [
+            Fore.YELLOW + 'Channel 1 MSW', Fore.YELLOW + 'Channel 1 LSW',
+            Fore.YELLOW + 'Channel 2 MSW', Fore.YELLOW + 'Channel 2 LSW',
+            Fore.YELLOW + 'Channel 3 MSW', Fore.YELLOW + 'Channel 3 LSW',
+            Fore.YELLOW + 'Channel 4 MSW', Fore.YELLOW + 'Channel 4 LSW',
+            Fore.YELLOW + 'Channel 5 MSW', Fore.YELLOW + 'Channel 5 LSW',
+            Fore.YELLOW + 'Channel 6 MSW', Fore.YELLOW + 'Channel 6 LSW',
+            Fore.YELLOW + 'Channel 7 MSW', Fore.YELLOW + 'Channel 7 LSW',
+            Fore.YELLOW + 'Channel 8 MSW', Fore.YELLOW + 'Channel 8 LSW',
+            Fore.YELLOW + 'Channel 1 OWD', Fore.YELLOW + 'Channel 2 OWD',
+            Fore.YELLOW + 'Channel 3 OWD', Fore.YELLOW + 'Channel 4 OWD',
+            Fore.YELLOW + 'HART IN 01', Fore.YELLOW + 'HART IN 02',
+            Fore.YELLOW + 'HART IN 03', Fore.YELLOW + 'HART IN 04',
+            Fore.YELLOW + 'HART IN 05', Fore.YELLOW + 'HART IN 06',
+            Fore.YELLOW + 'HART IN 07', Fore.YELLOW + 'HART IN 08',
+            Fore.YELLOW + 'HART IN 09', Fore.YELLOW + 'HART IN 10',
+            Fore.YELLOW + 'HART IN 11', Fore.YELLOW + 'HART IN 12',
+            Fore.YELLOW + 'HART IN 13', Fore.YELLOW + 'HART IN 14',
+            Fore.YELLOW + 'HART IN 15', Fore.YELLOW + 'HART IN 16',
+            Fore.YELLOW + 'HART IN 17', Fore.YELLOW + 'HART IN 18',
+            Fore.YELLOW + 'HART IN 19', Fore.YELLOW + 'HART IN 20',
+            Fore.YELLOW + 'HART IN 21', Fore.YELLOW + 'HART IN 22',
+            Fore.YELLOW + 'HART IN 23', Fore.YELLOW + 'HART IN 24',
+            Fore.YELLOW + 'HART IN 25', Fore.YELLOW + 'HART IN 26',
+            Fore.YELLOW + 'HART IN 27', Fore.YELLOW + 'HART IN 28',
+            Fore.YELLOW + 'HART IN 29', Fore.YELLOW + 'HART IN 30']
+        utilities.print_table(
+            register_address, registers_number, labels, registers)
+    return registers
+
+
+def read_board_current_channels(global_data: dict) -> None:
+    """Read a single board current channels.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        cs_address = request_adc_cs(global_data)
+        while True:
+            try:
+                currents = read_current_channels(global_data, cs_address)
+                print(Fore.GREEN + " ".join(
+                    str('{:+.5f} A'.format(element)) for element in currents))
+            except KeyboardInterrupt:
+                break
+            except OSError as error_message:
+                print(Fore.RED + 'Timeout error!', error_message)
+            except ValueError as error_message:
+                print(Fore.RED + 'Register operation error!', error_message)
+
+
+def read_board_voltage_channels(global_data: dict) -> None:
+    """Read a single board voltage channels.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        cs_address = request_adc_cs(global_data)
+        while True:
+            try:
+                voltages = read_voltage_channels(global_data, cs_address)
+                print(Fore.GREEN + " ".join(
+                    str('{:+.5f} V'.format(element)) for element in voltages))
+            except KeyboardInterrupt:
+                break
+            except OSError as error_message:
+                print(Fore.RED + 'Timeout error!', error_message)
+            except ValueError as error_message:
+                print(Fore.RED + 'Register operation error!', error_message)
+
+
+def read_current(
+        global_data: dict, channel_address: list, coding_type: int) -> float:
+    """Read current channels.
+
+    Args:
+        global_data: Dictionary with global variables
+        channel_address: List of MODBUS address, CS and channel number
+        coding_type: Bipolar or Unipolar
+
+    Returns:
+        Measured current value
+
+    """
+    register_address = utilities.generate_channel_register_address(
+        'I', channel_address)
+    analog_input_registers = global_data["INSTRUMENT"].read_registers(
+        register_address, 2, functioncode=4)
+    sleep(global_data["DELAY"])
+    code = hex(analog_input_registers[0])[2:].zfill(4) + \
+        hex(analog_input_registers[1])[2:].zfill(4)
+    if coding_type == 0:
+        current = (((int(code, 16) / 2**23) - 1) * 2.5) / 50
+    elif coding_type == 1:
+        current = (int(code, 16) * 2.5) / (2**24 * 50)
+    else:
+        print(Fore.RED + "Invalid ADC coding type!")
+    return current
+
+
+def read_current_channels(global_data: dict, board_address: int) -> float:
+    """Read current channels from an address.
+
+    Args:
+        global_data: Dictionary with global variables
+        board_address: CS value
+
+    Returns:
+        Measured current
+
+    """
+    values = []
+    for index in range(1, 5):
+        coding_type = read_output_holding_regs_cn0414(
+            global_data, [global_data["MODBUS_ADDRESS"], board_address, 0])[0]
+        values.append(read_current(
+            global_data, [global_data["MODBUS_ADDRESS"], board_address, index],
+            coding_type))
+    return values
+
+
+def read_device_current_channel(global_data: dict) -> None:
+    """Read current continuously from selected channel.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        cs_address = request_adc_cs(global_data)
+        print(Fore.CYAN + "Select current channel this list [1, 2, 3, 4],",
+              Fore.CYAN + "or press ENTER to use channel 1: ", end='')
+        input_data = input()
+        if input_data == '':
+            channel = 1
+        else:
+            channel = int(input_data)
+        coding_type = read_output_holding_regs_cn0414(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_address, 0])[0]
+        while True:
+            try:
+                current = read_current(
+                    global_data,
+                    [global_data["MODBUS_ADDRESS"], cs_address, channel],
+                    coding_type)
+                print(Fore.YELLOW + '{:+.9f} A'.format(current))
+            except KeyboardInterrupt:
+                break
+            except OSError as os_error_message:
+                print(Fore.RED + 'Timeout error!', os_error_message)
+            except ValueError as value_error_message:
+                print(Fore.RED + 'Register operation error!',
+                      value_error_message)
+
+
+def read_device_voltage_channel(global_data: dict) -> None:
+    """Read voltage continuously from selected channel.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        cs_address = request_adc_cs(global_data)
+        print(Fore.CYAN + "Select voltage channel this list [1, 2, 3, 4],",
+              Fore.CYAN + "or press ENTER to use channel 1: ", end='')
+        input_data = input()
+        if input_data == '':
+            channel = 1
+        else:
+            channel = int(input_data)
+        coding_type = read_output_holding_regs_cn0414(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_address, 0])[0]
+
+        while True:
+            try:
+                voltage = read_voltage(
+                    global_data,
+                    [global_data["MODBUS_ADDRESS"], cs_address, channel],
+                    coding_type)
+                print(Fore.YELLOW + "{:+.9f} V".format(voltage))
+            except KeyboardInterrupt:
+                break
+            except OSError as error_message:
+                print(Fore.RED + 'Timeout error!', error_message)
+            except ValueError as error_message:
+                print(Fore.RED + 'Register operation error!', error_message)
+
+
+def read_instrument_current_channels(global_data: dict) -> None:
+    """Read curent selected instrument current channels.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address ",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        while True:
+            try:
+                currents = []
+                for _, cs_address in enumerate(global_data["VALID_CS"]):
+                    board_currents = read_current_channels(
+                        global_data, cs_address)
+                    for index, _ in enumerate(board_currents):
+                        currents.append(board_currents[index])
+                print(Fore.GREEN + " ".join(
+                    str('{:+.5f} A'.format(element)) for element in currents))
+            except KeyboardInterrupt:
+                break
+            except OSError as error_message:
+                print(Fore.RED + 'Timeout error!', error_message)
+            except ValueError as error_message:
+                print(Fore.RED + 'Register operation error!', error_message)
+
+
+def read_instrument_voltage_channels(global_data: dict) -> None:
+    """Read curent selected instrument voltage channels.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        while True:
+            try:
+                voltages = []
+                for _, cs_address in enumerate(global_data["VALID_CS"]):
+                    board_voltages = read_voltage_channels(
+                        global_data, cs_address)
+                    for index, _ in enumerate(board_voltages):
+                        voltages.append(board_voltages[index])
+                print(Fore.GREEN + " ".join(
+                    str('{:+.5f} V'.format(element)) for element in voltages))
+            except KeyboardInterrupt:
+                break
+            except OSError as error_message:
+                print(Fore.RED + 'Timeout error!', error_message)
+            except ValueError as error_message:
+                print(Fore.RED + 'Register operation error!', error_message)
+
+
+def read_output_holding_regs_cn0414(
+        global_data: dict, address: list,
+        registers_number: int = 7, debug: bool = False) -> list:
+    """Read output holding registers.
+
+    Read output holding registers from CN0414 with function code 3.
+
+    Args:
+        instrument: Instrument object created by minimalmodbus
+        delay: Delay between MODBUS commands
+        address: MODBUS register start address
+        registers_number: Number of MODBUS register read (default value = 7)
+        debug: If True will print registers description and value
+            in a colored table (default value = False)
+
+    Returns:
+        Return a list of registers values
+
+    """
+    register_address = utilities.generate_register_address(address)
+    sleep(global_data["DELAY"])
+    registers = global_data["INSTRUMENT"].read_registers(
+        register_address, registers_number, functioncode=3)
+    if debug:
+        print(Fore.LIGHTMAGENTA_EX + '\nOutput holding registers at',
+              Fore.YELLOW + 'MODBUS address ' + str(address[1]))
+        labels = [
+            Fore.YELLOW + 'ADC Output Code',
+            Fore.YELLOW + 'ADC Filter',
+            Fore.YELLOW + 'ADC Postfilter',
+            Fore.YELLOW + 'ADC ODR',
+            Fore.YELLOW + 'ADC OWD EN',
+            Fore.YELLOW + 'HART cmd 0',
+            Fore.YELLOW + 'HART CH select']
+        utilities.print_table(
+            register_address, registers_number, labels, registers)
+    return registers
+
+
+def read_voltage(
+        global_data: dict, channel_address: list, coding_type: int) -> float:
+    """Read voltage channels.
+
+    Args:
+        global_data: Dictionary with global variables
+        channel_address: List of MODBUS address, CS and channel number
+        coding_type: Bipolar or Unipolar
+
+    Returns:
+        Measured voltage value
+
+    """
+    register_address = utilities.generate_channel_register_address(
+        'V', channel_address)
+    analog_input_registers = global_data["INSTRUMENT"].read_registers(
+        register_address, 2, functioncode=4)
+    sleep(global_data["DELAY"])
+    code = hex(analog_input_registers[0])[2:].zfill(4) + \
+        hex(analog_input_registers[1])[2:].zfill(4)
+    if coding_type == 0:
+        voltage = (((int(code, 16) / 2**23) - 1) * 2.5) / 0.1
+    elif coding_type == 1:
+        voltage = (int(code, 16) * 2.5) / (2**24 * 0.1)
+    else:
+        print(Fore.RED + "Invalid ADC coding type!")
+    return voltage
+
+
+def read_voltage_channels(global_data: dict, board_address: int) -> float:
+    """Read voltage channels from an address.
+
+    Args:
+        global_data: Dictionary with global variables
+        board_address: CS value
+
+    Returns:
+        Measured voltage
+
+    """
+    values = []
+    for index in range(1, 5):
+        coding_type = read_output_holding_regs_cn0414(
+            global_data, [global_data["MODBUS_ADDRESS"], board_address, 0])[0]
+        values.append(read_voltage(
+            global_data, [global_data["MODBUS_ADDRESS"], board_address, index],
+            coding_type))
+    return values
+
+
+def request_adc_cs(global_data: dict) -> int:
+    """Request ADC CS.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        CS address
+
+    """
+    valid_adc_cs = []
+    for index, _ in enumerate(global_data["BOARDS"]):
+        if global_data["BOARDS"][index] == '0':
+            valid_adc_cs.append(global_data["VALID_CS"][index])
+    while True:
+        print(Fore.CYAN + "Enter CS address from this list",
+              Fore.YELLOW + str(valid_adc_cs) + Fore.CYAN + ",",
+              Fore.CYAN + "or press ENTER to use CS",
+              Fore.YELLOW + str(valid_adc_cs[0]) + Fore.CYAN + ": ", end='')
+        input_data = input()
+        if input_data == '':
+            cs_address = valid_adc_cs[0]
+            break
+        elif int(input_data.split()[0]) not in valid_adc_cs:
+            print(Fore.YELLOW + "Invalid option. Try again.")
+        else:
+            cs_address = int(input_data)
+            break
+    return cs_address
+
+
+def select_hart_channel(global_data: dict) -> None:
+    """Select HART channel.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.CYAN + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Select HART channel:")
+        labels = ['Channel 1', 'Channel 2', 'Channel 3', 'Channel 4']
+        for index, _ in enumerate(labels):
+            print(Fore.YELLOW + '\t' + str(index) + ' for ' + labels[index])
+        cs_addr, reg_val = utilities.request_reconfig_data(global_data)
+        utilities.write_output_holding_reg(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, 6], reg_val)
+
+
+def send_hart_command_0(global_data: dict) -> None:
+    """Send HART command 0.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.CYAN + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Send HART command zero:")
+        print(Fore.YELLOW + '\t' + '1 to send HART command 0')
+        cs_addr, reg_val = utilities.request_reconfig_data(global_data)
+        utilities.write_output_holding_reg(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, 5], reg_val)
+        if reg_val == 1:
+            sleep(2)
+            registers = read_analog_input_regs_cn0414(
+                global_data, [global_data["MODBUS_ADDRESS"], cs_addr, 25], 30)
+            response = ''
+            for index, _ in enumerate(registers):
+                response += str(hex(registers[index]).upper()[2:]) + " "
+            print(Fore.GREEN + "DEVICE RESPONSE: " + Fore.YELLOW + response)
+
+
+def set_adc_filter(global_data: dict) -> None:
+    """Select ADC intrnal filter configuration.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Set ADC filter:")
+        labels = ['s5+s1', 's3']
+        for index, _ in enumerate(labels):
+            print(Fore.YELLOW + '\t' + str(index) + ' for ' + labels[index])
+        cs_addr, reg_val = utilities.request_reconfig_data(global_data)
+        utilities.write_output_holding_reg(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, 1], reg_val)
+
+
+def set_adc_open_wire_detection(global_data: dict) -> None:
+    """Set ADC open wire detection feature.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address ",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Set ADC output data rate:")
+        labels = ['disable open wire detection', 'enable open wire detection']
+        for index, _ in enumerate(labels):
+            print(Fore.YELLOW + '\t' + str(index) + ' for ' + labels[index])
+        cs_addr, reg_val = utilities.request_reconfig_data(global_data)
+        utilities.write_output_holding_reg(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, 4], reg_val)
+
+
+def set_adc_output_code(global_data: dict) -> None:
+    """Set ADC output data coding.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Set ADC output code:")
+        labels = ['bipolar coding', 'unipolar coding']
+        for index, _ in enumerate(labels):
+            print(Fore.YELLOW + '\t' + str(index) + ' for ' + labels[index])
+        cs_addr, reg_val = utilities.request_reconfig_data(global_data)
+        utilities.write_output_holding_reg(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, 0], reg_val)
+
+
+def set_adc_output_data_rate(global_data: dict) -> None:
+    """Set ADC output data rate.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Set ADC output data rate:")
+        labels = [
+            '31250 SPS', '31250 SPS', '31250 SPS', '31250 SPS', '31250 SPS',
+            '31250 SPS', '15625 SPS', '10417 SPS', '5208 SPS', '2597 SPS',
+            '1007 SPS', '503.8 SPS', '381 SPS', '200.3 SPS', '100.5 SPS',
+            '59.52 SPS', '49.68 SPS', '20.01 SPS', '16.63 SPS', '10 SPS',
+            '5 SPS', '2.5 SPS', '1.25 SPS']
+        for index, _ in enumerate(labels):
+            print(Fore.YELLOW + '\t' + str(index) + ' for ' + labels[index])
+        cs_addr, reg_val = utilities.request_reconfig_data(global_data)
+        utilities.write_output_holding_reg(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, 3], reg_val)
+
+
+def set_adc_postfilter(global_data: dict) -> None:
+    """Set ADC postfilter.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '0' not in global_data["BOARDS"]:
+        print(Fore.LIGHTMAGENTA_EX + "No analog input board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Set ADC postfilter:")
+        labels = ['27 SPS, 47 dB rejection, 36.7 ms settling',
+                  '25 SPS, 62 dB rejection, 40 ms settling',
+                  '20 SPS, 86 dB rejection, 50 ms settling',
+                  '16.67 SPS, 92 dB rejection, 60 ms settling',
+                  'disable postfilter']
+        for index, _ in enumerate(labels):
+            print(Fore.YELLOW + '\t' + str(index) + ' for ' + labels[index])
+        cs_addr, reg_val = utilities.request_reconfig_data(global_data)
+        utilities.write_output_holding_reg(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, 2], reg_val)

--- a/projects/ADuCM3029_demo_cn0435/Scripts/dcs_cn0418_utilities.py
+++ b/projects/ADuCM3029_demo_cn0435/Scripts/dcs_cn0418_utilities.py
@@ -1,0 +1,348 @@
+"""Base MODBUS functions.
+
+This module provide base functionalities to easy interact with:
+CN0414 - Analog input and HART for PLC/DCS systems
+CN0418 - Analog output and HART for PLC/DCS systems
+CN0416 - RS485 transceiver.
+"""
+
+__version__ = '0.1'
+__author__ = 'Mihai Ionut Suciu'
+__status__ = 'Development'
+
+from time import sleep
+from colorama import init, Fore
+import dcs_cn0435_utilities as utilities
+
+init(autoreset=True)
+
+
+def read_analog_input_regs_cn0418(
+        global_data: dict, address: int,
+        registers_number: int = 30, debug: bool = False) -> list:
+    """Read analog input registers.
+
+    Read analog input registers from CN0418 with function code 4.
+
+    Args:
+        global_data: Dictionary with global variables
+        address: MODBUS register start address
+        registers_number: Number of MODBUS register read (default value = 30)
+        debug: If True will print registers description and value
+            in a colored table (default value = False)
+
+    Returns:
+        Return a list of registers values
+
+    """
+    register_address = utilities.generate_register_address(address)
+    registers = global_data["INSTRUMENT"].read_registers(
+        register_address, registers_number, functioncode=4)
+    sleep(global_data["DELAY"])
+    if debug:
+        print(Fore.LIGHTMAGENTA_EX + '\nAnalog input registers at',
+              Fore.YELLOW + 'MODBUS address ' + str(address[1]))
+        labels = [
+            Fore.YELLOW + 'HART IN 01', Fore.YELLOW + 'HART IN 02',
+            Fore.YELLOW + 'HART IN 03', Fore.YELLOW + 'HART IN 04',
+            Fore.YELLOW + 'HART IN 05', Fore.YELLOW + 'HART IN 06',
+            Fore.YELLOW + 'HART IN 07', Fore.YELLOW + 'HART IN 08',
+            Fore.YELLOW + 'HART IN 09', Fore.YELLOW + 'HART IN 10',
+            Fore.YELLOW + 'HART IN 11', Fore.YELLOW + 'HART IN 12',
+            Fore.YELLOW + 'HART IN 13', Fore.YELLOW + 'HART IN 14',
+            Fore.YELLOW + 'HART IN 15', Fore.YELLOW + 'HART IN 16',
+            Fore.YELLOW + 'HART IN 17', Fore.YELLOW + 'HART IN 18',
+            Fore.YELLOW + 'HART IN 19', Fore.YELLOW + 'HART IN 20',
+            Fore.YELLOW + 'HART IN 21', Fore.YELLOW + 'HART IN 22',
+            Fore.YELLOW + 'HART IN 23', Fore.YELLOW + 'HART IN 24',
+            Fore.YELLOW + 'HART IN 25', Fore.YELLOW + 'HART IN 26',
+            Fore.YELLOW + 'HART IN 27', Fore.YELLOW + 'HART IN 28',
+            Fore.YELLOW + 'HART IN 29', Fore.YELLOW + 'HART IN 30']
+        utilities.print_table(
+            register_address, registers_number, labels, registers)
+    return registers
+
+
+def read_output_holding_regs_cn0418(
+        global_data: dict, address: list,
+        registers_number: int = 10, debug: bool = False) -> list:
+    """Read output holding registers.
+
+    Read output holding registers from CN0418 with function code 3.
+
+    Args:
+        global_data: Dictionary with global variables
+        address: MODBUS register start address
+        registers_number: Number of MODBUS register read (default value = 10)
+        debug: If True will print registers description and value
+            in a colored table (default value = False)
+
+    Returns:
+        Return a list of registers values
+
+    """
+    register_address = utilities.generate_register_address(address)
+    sleep(global_data["DELAY"])
+    registers = global_data["INSTRUMENT"].read_registers(
+        register_address, registers_number, functioncode=3)
+    if debug:
+        print(Fore.LIGHTMAGENTA_EX + '\nAnalog input registers at',
+              Fore.YELLOW + 'MODBUS address ' + str(address[1]))
+        labels = [
+            Fore.YELLOW + 'Channel 1 range',
+            Fore.YELLOW + 'Channel 2 range',
+            Fore.YELLOW + 'Channel 3 range',
+            Fore.YELLOW + 'Channel 4 range',
+            Fore.YELLOW + 'Channel 1',
+            Fore.YELLOW + 'Channel 2',
+            Fore.YELLOW + 'Channel 3',
+            Fore.YELLOW + 'Channel 4',
+            Fore.YELLOW + 'HART cmd 0',
+            Fore.YELLOW + 'HART CH select']
+        utilities.print_table(
+            register_address, registers_number, labels, registers)
+    return registers
+
+
+def request_dac_cs(global_data: dict) -> int:
+    """Request DAC CS.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        CS address
+
+    """
+    valid_dac_cs = []
+    for index, _ in enumerate(global_data["BOARDS"]):
+        if global_data["BOARDS"][index] == '1':
+            valid_dac_cs.append(global_data["VALID_CS"][index])
+    while True:
+        print(Fore.CYAN + "Enter CS address from this list",
+              Fore.YELLOW + str(valid_dac_cs) + Fore.CYAN + ",",
+              Fore.CYAN + "or press ENTER to use CS",
+              Fore.YELLOW + str(valid_dac_cs[0]) + Fore.CYAN + ": ", end='')
+        input_data = input()
+        if input_data == '':
+            cs_address = valid_dac_cs[0]
+            break
+        elif int(input_data.split()[0]) not in valid_dac_cs:
+            print(Fore.YELLOW + "Invalid option. Try again.")
+        else:
+            cs_address = int(input_data)
+            break
+    return cs_address
+
+
+def request_dac_reconfig_data(global_data: dict) -> tuple:
+    """Request device CS address and register value.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        Return requested device address and register value
+
+    """
+    cs_addr = request_dac_cs(global_data)
+
+    value_msg = "Enter register value, or press ENTER to use value 0: "
+    print(Fore.CYAN + value_msg, end='')
+    input_data = input()
+    if input_data == "":
+        reg_val = 0
+    else:
+        reg_val = int(input_data.split()[0])
+
+    return cs_addr, reg_val
+
+
+def select_channel_range(global_data: dict, channel: int) -> None:
+    """Select DAC channel output range, voltage or current output.
+
+    Args:
+        global_data: Dictionary with global variables
+        channel: Channel number
+
+    Returns:
+        None
+
+    """
+    if '1' not in global_data["BOARDS"]:
+        print(Fore.RED + "No analog output board available at MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Select channel range:")
+        labels = ['0V to 5V', '0V to 10V', '-5V to 5V', '-10V to 10V',
+                  '4mA to 20mA', '0mA to 20mA', '0mA to 24mA']
+        for index, _ in enumerate(labels):
+            print(Fore.YELLOW + '\t' + str(index) + ' for ' + labels[index])
+        cs_addr, reg_val = request_dac_reconfig_data(global_data)
+        utilities.write_output_holding_reg(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, channel - 1],
+            reg_val)
+
+
+def select_hart_channel(global_data: dict) -> None:
+    """Select HART channel.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '1' not in global_data["BOARDS"]:
+        print(Fore.CYAN + "No analog output board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Select HART channel:")
+        labels = ['Channel 1', 'Channel 2', 'Channel 3', 'Channel 4']
+        for index, _ in enumerate(labels):
+            print(Fore.YELLOW + '\t' + str(index) + ' for ' + labels[index])
+        cs_addr, reg_val = utilities.request_reconfig_data(global_data)
+        utilities.write_output_holding_reg(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, 6], reg_val)
+
+
+def send_hart_command_0(global_data: dict) -> None:
+    """Send HART command 0.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    if '1' not in global_data["BOARDS"]:
+        print(Fore.CYAN + "No analog output board available at",
+              Fore.CYAN + "MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Send HART command zero:")
+        print(Fore.YELLOW + '\t' + '1 to send HART command 0')
+        cs_addr, reg_val = utilities.request_reconfig_data(global_data)
+        utilities.write_output_holding_reg(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, 5], reg_val)
+
+
+def set_channel_output(global_data: dict, channel: int) -> None:
+    """Set DAC channel output value depending on current output range.
+
+    Args:
+        global_data: Dictionary with global variables
+        channel: Channel number
+
+    Returns:
+        None
+
+    """
+    if '1' not in global_data["BOARDS"]:
+        print(Fore.RED + "No analog output board available at MODBUS address",
+              Fore.CYAN + str(global_data["MODBUS_ADDRESS"]))
+    else:
+        print(Fore.CYAN + "Select channel output value:")
+        set_dac_output(global_data, channel)
+
+
+def set_dac_output(global_data: dict, channel: int) -> None:
+    """Request device CS address and register value.
+
+    Args:
+        global_data: Dictionary with global variables
+        channel: Channel number
+
+    Returns:
+        Return requested device address and register value
+
+    """
+    cs_addr = request_dac_cs(global_data)
+
+    detected_range = global_data["INSTRUMENT"].read_register(
+        utilities.generate_register_address(
+            [global_data["MODBUS_ADDRESS"], cs_addr, 0]))
+
+    if detected_range in range(4):
+        ranges = ['0V to 5V', '0V to 10V', '-5V to 5V', '-10V to 10V']
+        print(Fore.CYAN + "Enter a voltage value in [V] from range",
+              Fore.YELLOW + str(ranges[detected_range]),
+              Fore.CYAN + "or press ENTER to set",
+              Fore.YELLOW + "0V: ", end='')
+        input_data = input()
+        if input_data == "":
+            voltage_value = 0
+        else:
+            voltage_value = float(input_data.split()[0])
+        write_voltage(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, channel],
+            voltage_value, detected_range)
+    else:
+        ranges = ['4mA to 20mA', '0mA to 20mA', '0mA to 24mA']
+        print(Fore.CYAN + "Enter a current value in [mA] from range",
+              Fore.CYAN + str(ranges[detected_range - 4]),
+              Fore.CYAN + "or press ENTER to set",
+              Fore.YELLOW + "0mA: ", end='')
+        input_data = input()
+        if input_data == "":
+            current_value = 0
+        else:
+            current_value = float(input_data.split()[0]) / 1000
+        write_current(
+            global_data, [global_data["MODBUS_ADDRESS"], cs_addr, channel],
+            current_value, detected_range - 4)
+
+
+def write_current(
+        global_data: dict, channel_address: list,
+        channel_value: float, output_range: int):
+    """Write current channel.
+
+    Args:
+        global_data: Dictionary with global variables
+        channel_address: List of MODBUS address, CS and channel number
+        channel_value: Channel current value
+        output_range: Current range
+
+    Returns:
+        None"""
+    channel_address[2] += 3
+    if output_range == 0:
+        dac_code = int(((channel_value - 4) / 16) * 2**16)
+    elif output_range == 1:
+        dac_code = int((channel_value / 20) * 2**16)
+    elif output_range == 2:
+        dac_code = int((channel_value / 24) * 2**16)
+    else:
+        pass
+    utilities.write_output_holding_reg(global_data, channel_address, dac_code)
+
+
+def write_voltage(
+        global_data: dict, channel_address: list,
+        channel_value: float, output_range: int):
+    """Write voltage channel.
+
+    Args:
+        global_data: Dictionary with global variables
+        channel_address: List of MODBUS address, CS and channel number
+        channel_value: Channel voltage value
+        output_range: Voltage range
+
+    Returns:
+        None"""
+    channel_address[2] += 3
+    if output_range == 0:
+        dac_code = int((channel_value / 5.0) * 2**16)
+    elif output_range == 1:
+        dac_code = int((channel_value / 10.0) * 2**16)
+    elif output_range == 2:
+        dac_code = int(((channel_value + 5.0) / 10.0) * 2**16)
+    elif output_range == 3:
+        dac_code = int(((channel_value + 10.0) / 20.0) * 2**16)
+    else:
+        pass
+    utilities.write_output_holding_reg(global_data, channel_address, dac_code)

--- a/projects/ADuCM3029_demo_cn0435/Scripts/dcs_cn0435.py
+++ b/projects/ADuCM3029_demo_cn0435/Scripts/dcs_cn0435.py
@@ -1,0 +1,275 @@
+"""PLC MODBUS module.
+
+This module provide a simple terminal interface to easy interact with:
+    - CN0414 - Analog input and HART for PLC/DCS systems
+    - CN0418 - Analog output and HART for PLC/DCS systems
+    - CN0416 - RS485 transceiver
+Only one comunication port is used and a single MODBUS node.
+This application also allows to switch between MODBUS nodes if are available.
+
+"""
+
+__version__ = '0.1'
+__author__ = 'Mihai Ionut Suciu'
+__status__ = 'Development'
+
+from itertools import zip_longest
+from colorama import init, Fore
+import minimalmodbus
+from tabulate import tabulate
+import dcs_cn0435_utilities as utilities
+import dcs_cn0414_utilities as cn0414
+import dcs_cn0418_utilities as cn0418
+
+init(autoreset=True)
+
+
+def read_adc_data(test_option: str) -> None:
+    """Read ADC data.
+
+    Args:
+        test_option: Option value (number or letter)
+
+    Returns:
+        None
+
+    """
+    if test_option == '1':
+        cn0414.read_device_voltage_channel(GLOBAL_DATA)
+    elif test_option == '2':
+        cn0414.read_device_current_channel(GLOBAL_DATA)
+    elif test_option == '3':
+        cn0414.read_board_voltage_channels(GLOBAL_DATA)
+    elif test_option == '4':
+        cn0414.read_board_current_channels(GLOBAL_DATA)
+    elif test_option == '5':
+        cn0414.read_instrument_voltage_channels(GLOBAL_DATA)
+    elif test_option == '6':
+        cn0414.read_instrument_current_channels(GLOBAL_DATA)
+    else:
+        pass
+
+
+def read_registers(test_option: str) -> None:
+    """Read analog input or output holding registers.
+
+    Args:
+        test_option: Option value (number or letter)
+
+    Returns:
+        None
+
+    """
+    if test_option == 'o':
+        utilities.read_common_analog_input_regs(GLOBAL_DATA, debug=True)
+    elif test_option == 'p':
+        utilities.read_common_output_holding_regs(GLOBAL_DATA, debug=True)
+    elif test_option == 'r':
+        utilities.read_analog_input_regs_from_sys_config(GLOBAL_DATA)
+    elif test_option == 's':
+        utilities.read_output_holding_regs_from_sys_config(GLOBAL_DATA)
+    else:
+        pass
+
+
+def run_selected_function(test_option: str) -> None:
+    """Run selected function.
+
+    Args:
+        test_option: Option value (number or letter)
+
+    Returns:
+        None
+
+    """
+    options = ['1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd',
+               'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o',
+               'p', 'r', 's', 't', 'q']
+    if test_option in options:
+        read_registers(test_option)
+        set_adc_parametters(test_option)
+        read_adc_data(test_option)
+        write_dac_data(test_option)
+        set_hart(test_option)
+        if test_option == 't':
+            utilities.scan_system_config(PORT_NUMBER, DELAY)
+        elif test_option == 'q':
+            print(Fore.CYAN + "\nExit... Good Bye!")
+            exit(1)
+        else:
+            pass
+    else:
+        print(Fore.RED + 'No valid option selected!')
+
+
+def set_adc_parametters(test_option: str) -> None:
+    """Set ADC parametters.
+
+    Args:
+        test_option: Option value (number or letter)
+
+    Returns:
+        None
+
+    """
+    if test_option == '7':
+        cn0414.set_adc_output_code(GLOBAL_DATA)
+    elif test_option == '8':
+        cn0414.set_adc_filter(GLOBAL_DATA)
+    elif test_option == '9':
+        cn0414.set_adc_postfilter(GLOBAL_DATA)
+    elif test_option == 'a':
+        cn0414.set_adc_output_data_rate(GLOBAL_DATA)
+    elif test_option == 'b':
+        cn0414.set_adc_open_wire_detection(GLOBAL_DATA)
+    else:
+        pass
+
+
+def set_hart(test_option: str) -> None:
+    """Send HART command 0 or select HART channel.
+
+    Args:
+        test_option: Option value (number or letter)
+
+    Returns:
+        None
+
+    """
+    if test_option == 'c':
+        cn0414.send_hart_command_0(GLOBAL_DATA)
+    elif test_option == 'd':
+        cn0414.select_hart_channel(GLOBAL_DATA)
+    elif test_option == 'm':
+        cn0418.send_hart_command_0(GLOBAL_DATA)
+    elif test_option == 'n':
+        cn0418.select_hart_channel(GLOBAL_DATA)
+    else:
+        pass
+
+
+def test_options() -> str:
+    """Print test options.
+
+    Args:
+        None
+
+    Returns:
+        Keyboard input
+
+    """
+    cn0435_options = [
+        Fore.GREEN + 'o - Read common analog input registers',
+        Fore.GREEN + 'p - Read common output holding registers',
+        Fore.GREEN + 'r - Read analog input registers',
+        Fore.GREEN + 's - Read output holding registers',
+        Fore.GREEN + 't - Detect system configuration',
+        Fore.GREEN + '',
+        Fore.GREEN + '',
+        Fore.GREEN + '',
+        Fore.GREEN + '',
+        Fore.GREEN + '',
+        Fore.GREEN + '',
+        Fore.GREEN + '',
+        Fore.YELLOW + 'q - Quit']
+
+    cn0414_options = [
+        Fore.GREEN + '1 - Read device voltage channel',
+        Fore.GREEN + '2 - Read device current channel',
+        Fore.GREEN + '3 - Read board voltage channels',
+        Fore.GREEN + '4 - Read board current channels',
+        Fore.GREEN + '5 - Read instrument voltage channels',
+        Fore.GREEN + '6 - Read instrument current channels',
+        Fore.GREEN + '7 - Set ADC output code',
+        Fore.GREEN + '8 - Set ADC filter',
+        Fore.GREEN + '9 - Set ADC postfilter',
+        Fore.GREEN + 'a - Set ADC output data rate',
+        Fore.GREEN + 'b - Set ADC open wire detection state',
+        Fore.GREEN + 'c - Send HART command zero',
+        Fore.GREEN + 'd - Select HART channel']
+
+    cn0418_options = [
+        Fore.GREEN + 'e - Set DAC channel 1 output',
+        Fore.GREEN + 'f - Set DAC channel 2 output',
+        Fore.GREEN + 'g - Set DAC channel 3 output',
+        Fore.GREEN + 'h - Set DAC channel 4 output',
+        Fore.GREEN + 'i - Set DAC channel 1 range',
+        Fore.GREEN + 'j - Set DAC channel 2 range',
+        Fore.GREEN + 'k - Set DAC channel 3 range',
+        Fore.GREEN + 'l - Set DAC channel 4 range',
+        Fore.GREEN + 'm - Send HART command zero',
+        Fore.GREEN + 'n - Select HART channel']
+
+    print(Fore.CYAN + "\nUse CTRL+C to end a process or switch between nodes.")
+    print(tabulate(
+        headers=[Fore.YELLOW + 'CN0414',
+                 Fore.YELLOW + 'CN0418',
+                 Fore.YELLOW + 'CN0435'],
+        tabular_data=list(
+            zip_longest(cn0414_options, cn0418_options, cn0435_options))))
+    print(Fore.CYAN + "\nEnter Option: ", end='')
+
+    return input()
+
+
+def write_dac_data(test_option: str) -> None:
+    """Write DAC data.
+
+    Args:
+        test_option: Option value (number or letter)
+
+    Returns:
+        None
+
+    """
+    if test_option == 'e':
+        cn0418.select_channel_range(GLOBAL_DATA, 1)
+    elif test_option == 'f':
+        cn0418.select_channel_range(GLOBAL_DATA, 2)
+    elif test_option == 'g':
+        cn0418.select_channel_range(GLOBAL_DATA, 3)
+    elif test_option == 'h':
+        cn0418.select_channel_range(GLOBAL_DATA, 4)
+    elif test_option == 'i':
+        cn0418.set_channel_output(GLOBAL_DATA, 1)
+    elif test_option == 'j':
+        cn0418.set_channel_output(GLOBAL_DATA, 2)
+    elif test_option == 'k':
+        cn0418.set_channel_output(GLOBAL_DATA, 3)
+    elif test_option == 'l':
+        cn0418.set_channel_output(GLOBAL_DATA, 4)
+    else:
+        pass
+
+
+if __name__ == "__main__":
+    DATA = utilities.request_info()
+    PORT_NUMBER, MODBUS_ADDRESS = DATA[0], DATA[1]
+    MODBUS_TIMEOUT, DELAY = DATA[2], DATA[3]
+    VALID_CS, BOARDS = DATA[4], DATA[5]
+
+    while True:
+        try:
+            INSTRUMENT = minimalmodbus.Instrument(PORT_NUMBER, MODBUS_ADDRESS)
+            INSTRUMENT.serial.timeout = MODBUS_TIMEOUT
+
+            GLOBAL_DATA = {
+                "INSTRUMENT": INSTRUMENT,
+                "MODBUS_ADDRESS": MODBUS_ADDRESS,
+                "DELAY": DELAY,
+                "VALID_CS": VALID_CS,
+                "BOARDS": BOARDS
+            }
+
+            while True:
+                try:
+                    run_selected_function(test_options())
+                except OSError as error_message:
+                    print(Fore.RED + 'Timeout error!', error_message)
+                except ValueError as error_message:
+                    print(Fore.RED + 'Register operation error!',
+                          error_message)
+        except KeyboardInterrupt:
+            print(Fore.CYAN + "\nSwitch to a new MODBUS address... ")
+            DATA = utilities.switch_modbus_address(PORT_NUMBER, MODBUS_ADDRESS)
+            MODBUS_ADDRESS, VALID_CS, BOARDS = DATA[0], DATA[1], DATA[2]

--- a/projects/ADuCM3029_demo_cn0435/Scripts/dcs_cn0435_utilities.py
+++ b/projects/ADuCM3029_demo_cn0435/Scripts/dcs_cn0435_utilities.py
@@ -1,0 +1,556 @@
+"""Base MODBUS functions.
+
+This module provide base functionalities to easy interact with:
+CN0414 - Analog input and HART for PLC/DCS systems
+CN0418 - Analog output and HART for PLC/DCS systems
+CN0416 - RS485 transceiver.
+"""
+
+__version__ = '0.1'
+__author__ = 'Mihai Ionut Suciu'
+__status__ = 'Development'
+
+import sys
+from time import sleep
+from colorama import init, Fore
+from tabulate import tabulate
+import serial.tools.list_ports
+import minimalmodbus
+import dcs_cn0414_utilities as cn0414
+import dcs_cn0418_utilities as cn0418
+
+init(autoreset=True)
+
+
+def detect_system_configuration(global_data: dict) -> tuple:
+    """Detect boards connected.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        Tuple of two lists
+
+    """
+    registers = read_common_analog_input_regs(global_data)
+    valid_addr, boards = [], []
+    for index in range(1, 5):
+        if registers[index] < 8:
+            board_address = format(registers[index], '03b')[:2]
+            board_type = format(registers[index], '03b')[2:]
+            valid_addr.append(int(board_address, 2))
+            if board_type == '0':
+                print(Fore.GREEN + 'Analog input board at address:',
+                      Fore.YELLOW + str(board_address))
+                boards.append(0)
+            elif board_type == '1':
+                print(Fore.GREEN + 'Analog output board at address:',
+                      Fore.YELLOW + str(board_address))
+                boards.append(1)
+            else:
+                pass
+    print()
+    return valid_addr, boards
+
+
+def generate_channel_register_address(channel_type: str, address: list) -> int:
+    """Generate channel register address.
+
+    Args:
+        channel_type:
+            - If "V" voltage channel is selected
+            - If "I" current channel is selected
+        address: List of MODBUS address, CS and channel number
+
+    Returns:
+        Register address
+
+    """
+    if channel_type == 'V':
+        offset = 5
+    elif channel_type == 'I':
+        offset = 13
+    else:
+        print('Invalid channel type option.')
+    bin_modbus_addr = bin(address[0])[2:].zfill(4)
+    bin_cs_addr = bin(address[1])[2:].zfill(4)
+    bin_channel_addr = bin((2 * (address[2] - 1)) + offset)[2:].zfill(8)
+    register_address = int(bin_cs_addr + bin_modbus_addr + bin_channel_addr, 2)
+    return register_address
+
+
+def generate_register_address(address: list) -> int:
+    """Generate register address from a list.
+
+    Args:
+        address: list used to generate the the registers address
+
+    Returns:
+        Return the registers address
+
+    """
+    bin_modbus_addr = bin(address[0])[2:].zfill(4)
+    bin_cs_addr = bin(address[1])[2:].zfill(4)
+    bin_offset_addr = bin(address[2])[2:].zfill(8)
+    register_address = int(bin_cs_addr + bin_modbus_addr + bin_offset_addr, 2)
+    return register_address
+
+
+def print_table(register_address: int, register_count: int,
+                labels: list, registers: list) -> None:
+    """Print data in a table.
+
+    Print registers addresses, description and
+        current value in a colored table format.
+
+    Args:
+        register_address: First register number
+        register_count: Number of registers
+        labels: Registers description
+        registers: Registers values
+
+    Returns:
+        None
+
+    """
+    register_list = range(register_address, register_address + register_count)
+    address_list = []
+    for index, _ in enumerate(register_list):
+        dec_address = Fore.GREEN + str(register_list[index]).zfill(4)
+        hex_address = Fore.GREEN + ' (0x{0:04X})'.format(register_list[index])
+        address_list.append(dec_address + hex_address)
+    values = []
+    for index, _ in enumerate(labels):
+        values.append(Fore.GREEN + str(registers[index]))
+    print(tabulate(headers=[Fore.CYAN + 'Address',
+                            Fore.CYAN + 'Name',
+                            Fore.CYAN + 'Value'],
+                   tabular_data=list(zip(address_list, labels, values))))
+
+
+def read_analog_input_regs_from_sys_config(global_data: dict) -> None:
+    """Read analog input registers from detected system configuration.
+
+    Determine the number and type (analog input/output) of the boards detected
+    in the curent system configuration and read all analog input registers.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    system_config = detect_system_configuration(global_data)
+    boards_detected, boards_types = system_config[0], system_config[1]
+    for count, _ in enumerate(boards_detected):
+        cs_address = boards_detected[count]
+        if boards_types[count] == 0:
+            cn0414.read_analog_input_regs_cn0414(
+                global_data, [global_data["MODBUS_ADDRESS"], cs_address, 5],
+                debug=True)
+        elif boards_types[count] == 1:
+            cn0418.read_analog_input_regs_cn0418(
+                global_data, [global_data["MODBUS_ADDRESS"], cs_address, 5],
+                debug=True)
+        else:
+            pass
+
+
+def read_common_analog_input_regs(
+        global_data: dict, register_address: int = 0,
+        registers_number: int = 5, debug: bool = False) -> list:
+    """Read common analog input registers.
+
+    Read common analog input registers with function code 4.
+
+    Args:
+        global_data: Dictionary with global variables
+        register_address: MODBUS register start address (default value = 0)
+        registers_number: Number of MODBUS register read (default value = 5)
+        debug: If True will print registers description and value
+            in a colored table (default value = False)
+
+    Returns:
+        Return a list of registers values
+
+    """
+    sleep(global_data["DELAY"])
+    registers = global_data["INSTRUMENT"].read_registers(
+        register_address, registers_number, functioncode=4)
+    if debug:
+        print(Fore.LIGHTMAGENTA_EX + '\nCommon analog input registers:')
+        labels = [
+            Fore.YELLOW + 'Detected boards',
+            Fore.YELLOW + 'First board data',
+            Fore.YELLOW + 'Second board data',
+            Fore.YELLOW + 'Third board data',
+            Fore.YELLOW + 'Fourth board data']
+        print_table(register_address, registers_number, labels, registers)
+    return registers
+
+
+def read_common_output_holding_regs(
+        global_data: dict, register_address: int = 254,
+        registers_number: int = 2, debug: bool = False) -> list:
+    """Read common output holding registers.
+
+    Read common output holding registers with function code 3.
+
+    Args:
+        global_data: Dictionary with global variables
+        register_address: MODBUS register start address (default value = 254)
+        registers_number: Number of MODBUS register read (default value = 2)
+        debug: If True will print registers description and value
+            in a colored table (default value = False)
+
+    Returns:
+        Return a list of registers values
+
+    """
+    sleep(global_data["DELAY"])
+    registers = global_data["INSTRUMENT"].read_registers(
+        register_address, registers_number, functioncode=3)
+    if debug:
+        print(Fore.LIGHTMAGENTA_EX + '\nCommon output holding registers:')
+        labels = [
+            Fore.YELLOW + 'Update rate MSW',
+            Fore.YELLOW + 'Update rate LSW']
+        print_table(register_address, registers_number, labels, registers)
+    return registers
+
+
+def read_output_holding_regs_from_sys_config(global_data: dict) -> None:
+    """Read output holding registers from detected system configuration.
+
+    Determine the number and type (analog input/output) of the boards detected
+    in the curent system configuration and read all output holding registers.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+    system_config = detect_system_configuration(global_data)
+    boards_detected, boards_types = system_config[0], system_config[1]
+    for count, _ in enumerate(boards_detected):
+        cs_address = boards_detected[count]
+        if boards_types[count] == 0:
+            cn0414.read_output_holding_regs_cn0414(
+                global_data, [global_data["MODBUS_ADDRESS"], cs_address, 0],
+                debug=True)
+        elif boards_types[count] == 1:
+            cn0418.read_output_holding_regs_cn0418(
+                global_data, [global_data["MODBUS_ADDRESS"], cs_address, 0],
+                debug=True)
+        else:
+            pass
+
+
+def request_cs_data(global_data: dict) -> int:
+    """Request CS address.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        CS address
+
+    """
+    while True:
+        print(Fore.CYAN + "Enter CS address from this list",
+              Fore.YELLOW + str(global_data["VALID_CS"]) + Fore.CYAN + ",",
+              Fore.CYAN + "or press ENTER to use CS",
+              Fore.YELLOW + str(global_data["VALID_CS"][0]) + Fore.CYAN + ": ",
+              end='')
+        input_data = input()
+        if input_data == "":
+            cs_addr = global_data["VALID_CS"][0]
+            break
+        elif int(input_data.split()[0]) not in global_data["VALID_CS"]:
+            print(Fore.YELLOW + "Invalid option. Try again.")
+        else:
+            cs_addr = int(input_data.split()[0])
+            break
+    return cs_addr
+
+
+def request_info() -> str:
+    """Request input data.
+
+    List all serial devices detected in use and wait for the user to choose
+    which port/serial device want to use.
+
+    Args:
+        None
+
+    Returns:
+        Return requested port name, modbus address,modbus timeout, delay
+        between commands and devices address(es) for current MODBUS address
+
+    """
+    print(Fore.CYAN + "\nWelcome! ", end='')
+    print(Fore.CYAN + "Use 'CTRL+C' to go back from the current menu or exit!")
+
+    devices, ports = serial_devices()
+
+    print(Fore.GREEN + '\nAvailable devices:',
+          Fore.YELLOW + " ".join(str(element) for element in devices))
+
+    default = Fore.GREEN + "or press ENTER to use " + ports[0] + ": "
+    print(Fore.GREEN + "\nEnter detected device index,", default, end='')
+    input_data = input()
+    if input_data == '':
+        port_number = 0
+    else:
+        port_number = int(input_data) - 1
+
+    default = Fore.GREEN + "or press ENTER to use 0.1[s] timeout: "
+    print(Fore.GREEN + "Enter MODBUS timeout (0.05[s] to inf),", default,
+          end='')
+    timeout = input()
+    if timeout == '':
+        timeout = 0.1
+    elif float(timeout) <= 0.05:
+        timeout = 0.05
+    else:
+        timeout = float((timeout.split()[0]))
+
+    modbus_address, current_cs_list, current_boards = switch_modbus_address(
+        ports[port_number], timeout)
+
+    default = Fore.GREEN + "or press ENTER to use 0.1[s] delay: "
+    print(Fore.GREEN + "Enter commands delay (0[s] to inf),", default, end='')
+    delay = input()
+    if delay == '':
+        delay = 0.1
+    else:
+        delay = float((delay.split()[0]))
+
+    return ports[port_number], modbus_address, timeout, delay, \
+        current_cs_list, current_boards
+
+
+def request_reconfig_data(global_data: dict) -> tuple:
+    """Request device CS address and register value.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        Return requested device address and register value
+
+    """
+    cs_addr = request_cs_data(global_data)
+
+    value_msg = "Enter register value, or press ENTER to use value 0: "
+    print(Fore.CYAN + value_msg, end='')
+    input_data = input()
+    if input_data == "":
+        reg_val = 0
+    else:
+        reg_val = int(input_data.split()[0])
+
+    return cs_addr, reg_val
+
+
+def select_and_write_register(global_data: dict) -> None:
+    """Write any output holding register.
+
+    Args:
+        global_data: Dictionary with global variables
+
+    Returns:
+        None
+
+    """
+
+    cs_addr = request_cs_data(global_data)
+
+    offset_msg = "Enter offset address, or press ENTER to use offset 0: "
+    print(Fore.CYAN + offset_msg, end='')
+    input_data = input()
+    if input_data == "":
+        offset_addr = 0
+    else:
+        offset_addr = int(input_data.split()[0])
+
+    value_msg = "Enter register value, or press ENTER to use value 0: "
+    print(Fore.CYAN + value_msg, end='')
+    input_data = input()
+    if input_data == "":
+        reg_val = 0
+    else:
+        reg_val = int(input_data.split()[0])
+
+    write_output_holding_reg(
+        global_data, [global_data["MODBUS_ADDRESS"], cs_addr, offset_addr],
+        reg_val)
+
+
+def scan_system_config(port_name: str, delay: float) -> None:
+    """Detect system configuration for each possible MODBUS node.
+
+    Create an instrument object for each MODBUS node and read 5 analog
+    input registers with function code 4 starting from address 0.
+    Print registers description and value in a colored table.
+    Convert first 4 registers value in binary format and check if the least
+    significant bit is 0 or 1. If 0 is found, an analog input board have been
+    detected, else, if 1 is found, an analog output board have been detected.
+
+    Args:
+        port_name: COMPORT name
+
+    Returns:
+        None
+    """
+    valid_modbus_addresses, current_cs, all_valid_cs = [], [], []
+    current_board_type, all_boards = [], []
+    for modbus_index in range(1, 17):
+        try:
+            instrument = minimalmodbus.Instrument(port_name, modbus_index)
+            registers = instrument.read_registers(0, 5, 4)
+            valid_modbus_addresses.append(modbus_index)
+            sleep(delay)
+            print(Fore.GREEN + '\nBoards found at MODBUS address:',
+                  Fore.YELLOW + str(modbus_index))
+            labels = [
+                Fore.YELLOW + 'Detected boards',
+                Fore.YELLOW + 'First board data',
+                Fore.YELLOW + 'Second board data',
+                Fore.YELLOW + 'Third board data',
+                Fore.YELLOW + 'Fourth board data']
+            print_table(0, 5, labels, registers)
+            for index in range(1, 5):
+                if registers[index] < 8:
+                    board_address = format(registers[index], '03b')[:2]
+                    board_type = format(registers[index], '03b')[2:]
+                    if board_type == '0':
+                        print(Fore.GREEN + 'analog input board at address:',
+                              Fore.YELLOW + str(board_address))
+                        current_cs.append(int('0b' + board_address, 2))
+                        current_board_type.append('0')
+                    elif board_type == '1':
+                        print(Fore.GREEN + 'analog output board at address:',
+                              Fore.YELLOW + str(board_address))
+                        current_cs.append(int('0b' + board_address, 2))
+                        current_board_type.append('1')
+                    else:
+                        pass
+            all_valid_cs.append(current_cs)
+            all_boards.append(current_board_type)
+            current_cs, current_board_type = [], []
+        except OSError as os_error_message:
+            print(Fore.LIGHTMAGENTA_EX + 'No boards at MODBUS address:',
+                  Fore.YELLOW + str(modbus_index),
+                  Fore.CYAN + str(os_error_message))
+    return valid_modbus_addresses, all_valid_cs, all_boards
+
+
+def serial_devices() -> tuple:
+    """Lists serial port names and description.
+
+    Search for all serial devices detected in use and return
+    their description and port name as a list with an index.
+
+    Args:
+        None
+
+    Returns:
+        Return a tuple of two lists, serial device(s) description(s)
+        and serial device(s) port(s).
+
+    """
+    devices, ports = [], []
+    all_ports = serial.tools.list_ports.comports()
+    for index, current_port in enumerate(all_ports, 1):
+        devices.append("\n" + str(index) + " -> " + current_port.description)
+        ports.append(current_port.device)
+    return devices, ports
+
+
+def serial_ports() -> list:
+    """Lists serial port names.
+
+    Args:
+        None
+
+    Returns:
+        List of detected serial ports.
+
+    """
+    if sys.platform.startswith('win'):
+        ports = ['COM%s' % (i + 1) for i in range(256)]
+    else:
+        raise EnvironmentError('Unsupported platform')
+
+    result = []
+    for port in ports:
+        try:
+            serial_port = serial.Serial(port)
+            serial_port.close()
+            result.append(port)
+        except (OSError, serial.SerialException):
+            pass
+    print(result)
+    return result
+
+
+def switch_modbus_address(selected_port: str, timeout: float) -> tuple:
+    """Switch between MODBUS address.
+
+    Args:
+        selected_port: Port name
+        timeout: MODBUS timeout
+
+    Returns:
+        Return a tuple of two lists, MODBUS address(es)
+        and detected device(s) address(es).
+
+    """
+    modbus_list, all_valid_cs, all_boards = scan_system_config(
+        selected_port, timeout)
+
+    while True:
+        print(Fore.GREEN + "\nEnter MODBUS address from this list",
+              Fore.YELLOW + str(modbus_list) + Fore.GREEN + ",",
+              Fore.GREEN + "or press ENTER to use MODBUS address",
+              Fore.YELLOW + str(modbus_list[0]) + Fore.GREEN + ': ', end='')
+        modbus_address = input()
+        if modbus_address == '':
+            modbus_address = modbus_list[0]
+            current_cs_list = all_valid_cs[0]
+            current_boards_list = all_boards[0]
+            break
+        elif int((modbus_address.split()[0])) not in modbus_list:
+            print(Fore.YELLOW + "Invalid option. Try again.")
+        else:
+            modbus_address = int((modbus_address.split()[0]))
+            current_cs_list = all_valid_cs[modbus_list.index(modbus_address)]
+            current_boards_list = all_boards[modbus_list.index(modbus_address)]
+            break
+    return modbus_address, current_cs_list, current_boards_list
+
+
+def write_output_holding_reg(
+        global_data: dict, address: list, registers_values: int) -> None:
+    """Write output holding register.
+
+    Write a single output holding register with function code 6.
+
+    Args:
+        instrument: Instrument object created by minimalmodbus
+        delay: Delay between MODBUS commands
+        address: MODBUS register address
+        registers_values: New MODBUS register value to be write
+
+    Returns:
+        None
+
+    """
+    register_address = generate_register_address(address)
+    sleep(global_data["DELAY"])
+    global_data["INSTRUMENT"].write_register(
+        register_address, registers_values, functioncode=6)

--- a/projects/ADuCM3029_demo_cn0435/Scripts/detect_configuration.py
+++ b/projects/ADuCM3029_demo_cn0435/Scripts/detect_configuration.py
@@ -1,0 +1,189 @@
+"""Detect configuration module.
+
+This module provide a simple way to detect the PLC/DCS configuration.
+In this way the user can easy detect boards like:
+    - CN0414 (Analog input and HART compatible)
+    - CN0418 (Analog output and HART compatible)
+The CN0416 (RS485 transceiver) needs to be used in a DCS configuration,
+while for a PLC configuration is optional.
+
+Only one comunication port is used and needs to be chosen by the user.
+"""
+
+__version__ = '0.1'
+__author__ = 'Mihai Ionut Suciu'
+__status__ = 'Development'
+
+from time import sleep
+from colorama import init, Fore
+import minimalmodbus
+import serial.tools.list_ports
+from tabulate import tabulate
+
+init(autoreset=True)
+
+
+def request_info() -> str:
+    """Request input data.
+
+    List all serial devices detected in use and wait for the user to choose
+    which port/serial device want to use.
+
+    Args:
+        None
+
+    Returns:
+        Return requested port name
+
+    """
+    print(Fore.CYAN + "\nWelcome! ", end='')
+    print(Fore.CYAN + "Use 'CTRL+C' to go back from current menu or exit!")
+
+    devices, ports = serial_devices()
+
+    print(Fore.GREEN + '\nAvailable devices:',
+          Fore.YELLOW + " ".join(str(element) for element in devices))
+
+    default = Fore.GREEN + "or press ENTER to use " + ports[0] + ": "
+    print(Fore.GREEN + "\nEnter detected device index,", default, end='')
+    input_data = input()
+    if input_data == '':
+        port_number = 0
+    else:
+        port_number = int(input_data) - 1
+    return ports[port_number]
+
+
+def serial_devices() -> tuple:
+    """Lists serial port names and description.
+
+    Search for all serial devices detected in use and return
+    their description and port name as a list with an index.
+
+    Args:
+        None
+
+    Returns:
+        Return a tuple of two lists, serial device(s) description(s)
+        and serial device(s) port(s).
+    """
+    devices, ports = [], []
+    all_ports = serial.tools.list_ports.comports()
+    for index, current_port in enumerate(all_ports, 1):
+        devices.append("\n" + str(index) + " -> " + current_port.description)
+        ports.append(current_port.device)
+    return devices, ports
+
+
+def search_serial_port_id(
+        device_description: str, view_device_description: bool = False) -> str:
+    """Search for a serial device description.
+
+    Args:
+        device_description: Device description string
+        view_device_description: flag to display device description
+
+    Returns:
+        Device port name
+    """
+    devices, descriptions, device_port = [], [], None
+    all_ports = serial.tools.list_ports.comports()
+    for current_port in all_ports:
+        devices.append(current_port.device)
+        descriptions.append(current_port.description)
+        for index, _ in enumerate(descriptions):
+            if descriptions[index] == device_description:
+                device_port = devices[index]
+    if view_device_description:
+        print(descriptions)
+    return device_port
+
+
+def print_table(
+        register_address: int, register_count: int,
+        labels: list, registers: list) -> None:
+    """Print data in a table.
+
+    Print registers addresses, description and
+        current value in a colored table format.
+
+    Args:
+        register_address: First register number
+        register_count: Number of registers
+        labels: Registers description
+        registers: Registers values
+
+    Returns:
+        None
+    """
+    register_list = range(register_address, register_address + register_count)
+    address_list = []
+    for index, _ in enumerate(register_list):
+        dec_address = Fore.GREEN + str(register_list[index]).zfill(4)
+        hex_address = Fore.GREEN + ' (0x{0:04X})'.format(register_list[index])
+        address_list.append(dec_address + hex_address)
+    values = []
+    for index, _ in enumerate(labels):
+        values.append(Fore.GREEN + str(registers[index]))
+    print(tabulate(headers=[Fore.CYAN + 'Address',
+                            Fore.CYAN + 'Name',
+                            Fore.CYAN + 'Value'],
+                   tabular_data=list(zip(address_list, labels, values))))
+
+
+def scan_system_config(port_name: str) -> None:
+    """Detect system configuration for each possible MODBUS node.
+
+    Create an instrument object for each MODBUS node and read 5 analog
+    input registers with function code 4 starting from address 0.
+    Print registers description and value in a colored table.
+    Convert first 4 registers value in binary format and check if the least
+    significant bit is 0 or 1. If 0 is found, an analog input board have been
+    detected, else, if 1 is found, an analog output board have been detected.
+
+    Args:
+        port_name: COMPORT name
+
+    Returns:
+        None
+    """
+    for modbus_index in range(1, 17):
+        try:
+            instrument = minimalmodbus.Instrument(port_name, modbus_index)
+            registers = instrument.read_registers(0, 5, 4)
+            sleep(0.05)
+            print(Fore.GREEN + '\nBoards found at MODBUS address:',
+                  Fore.YELLOW + str(modbus_index))
+            labels = [
+                Fore.YELLOW + 'Detected boards',
+                Fore.YELLOW + 'First board data',
+                Fore.YELLOW + 'Second board data',
+                Fore.YELLOW + 'Third board data',
+                Fore.YELLOW + 'Fourth board data']
+            print_table(0, 5, labels, registers)
+            for index in range(1, 5):
+                if registers[index] < 8:
+                    board_address = format(registers[index], '03b')[:2]
+                    board_type = format(registers[index], '03b')[2:]
+                    if board_type == '0':
+                        print(Fore.GREEN + 'Analog input board at address:',
+                              Fore.YELLOW + str(board_address))
+                    elif board_type == '1':
+                        print(Fore.GREEN + 'Analog output board at address:',
+                              Fore.YELLOW + str(board_address))
+                    else:
+                        pass
+        except OSError as os_error_message:
+            print(Fore.LIGHTMAGENTA_EX + 'No boards at MODBUS address:',
+                  Fore.YELLOW + str(modbus_index),
+                  Fore.CYAN + str(os_error_message))
+
+
+if __name__ == "__main__":
+    try:
+        PORT = request_info()
+        scan_system_config(PORT)
+    except OSError as os_error_message:
+        print(Fore.RED + 'Timeout error!', os_error_message)
+    except ValueError as value_error_message:
+        print(Fore.RED + 'Register operation error!', value_error_message)

--- a/projects/ADuCM3029_demo_cn0435/Scripts/read_write_modbus_registers.py
+++ b/projects/ADuCM3029_demo_cn0435/Scripts/read_write_modbus_registers.py
@@ -1,0 +1,105 @@
+"""PLC MODBUS module.
+
+This module provide a simple terminal interface to easy interact with:
+    - CN0414 - Analog input and HART for PLC/DCS systems
+    - CN0418 - Analog output and HART for PLC/DCS systems
+    - CN0416 - RS485 transceiver
+Only one comunication port is used and a single MODBUS node.
+This application also allows to switch between MODBUS nodes if are available.
+
+"""
+
+__version__ = '0.1'
+__author__ = 'Mihai Ionut Suciu'
+__status__ = 'Development'
+
+from colorama import init, Fore
+import minimalmodbus
+import dcs_cn0435_utilities as utilities
+
+init(autoreset=True)
+
+
+def run_selected_function(test_option: str) -> None:
+    """Run selected function.
+
+    Args:
+        test_option: Option value (number or letter)
+
+    Returns:
+        None
+
+    """
+    options = ['1', '2', '3', '4', '5', 'q']
+    if test_option in options:
+        if test_option == '1':
+            utilities.read_common_analog_input_regs(GLOBAL_DATA, debug=True)
+        elif test_option == '2':
+            utilities.read_common_output_holding_regs(GLOBAL_DATA, debug=True)
+        elif test_option == '3':
+            utilities.read_analog_input_regs_from_sys_config(GLOBAL_DATA)
+        elif test_option == '4':
+            utilities.read_output_holding_regs_from_sys_config(GLOBAL_DATA)
+        elif test_option == '5':
+            utilities.select_and_write_register(GLOBAL_DATA)
+        elif test_option == 'q':
+            print(Fore.CYAN + "\nExit... Good Bye!")
+            exit(1)
+        else:
+            pass
+    else:
+        print(Fore.RED + 'No valid option selected!')
+
+
+def test_options() -> str:
+    """Print test options.
+
+    Args:
+        None
+
+    Returns:
+        Keyboard input
+
+    """
+    print(Fore.LIGHTMAGENTA_EX + "\nTest options:")
+    print(Fore.LIGHTMAGENTA_EX + "1 - Read common analog input registers.")
+    print(Fore.LIGHTMAGENTA_EX + "2 - Read common output holding registers.")
+    print(Fore.LIGHTMAGENTA_EX + "3 - Read analog input registers.")
+    print(Fore.LIGHTMAGENTA_EX + "4 - Read output holding registers.")
+    print(Fore.LIGHTMAGENTA_EX + "5 - Write output holding register.")
+    print(Fore.LIGHTMAGENTA_EX + "q - Quit.")
+    print(Fore.GREEN + "\nEnter test option: ", end='')
+    return input()
+
+
+if __name__ == "__main__":
+    DATA = utilities.request_info()
+    PORT_NUMBER, MODBUS_ADDRESS = DATA[0], DATA[1]
+    MODBUS_TIMEOUT, DELAY = DATA[2], DATA[3]
+    VALID_CS, BOARDS = DATA[4], DATA[5]
+
+    while True:
+        try:
+            INSTRUMENT = minimalmodbus.Instrument(PORT_NUMBER, MODBUS_ADDRESS)
+            INSTRUMENT.serial.timeout = MODBUS_TIMEOUT
+
+            GLOBAL_DATA = {
+                "INSTRUMENT": INSTRUMENT,
+                "MODBUS_ADDRESS": MODBUS_ADDRESS,
+                "DELAY": DELAY,
+                "VALID_CS": VALID_CS,
+                "BOARDS": BOARDS
+            }
+
+            while True:
+                try:
+                    run_selected_function(test_options())
+                except OSError as error_message:
+                    print(Fore.RED + 'Timeout error!', error_message)
+                except ValueError as error_message:
+                    print(Fore.RED + 'Register operation error!',
+                          error_message)
+        except KeyboardInterrupt:
+            print(Fore.CYAN + "\nSwitch to a new MODBUS address... ")
+            DATA = utilities.switch_modbus_address(PORT_NUMBER, MODBUS_ADDRESS)
+            MODBUS_ADDRESS, VALID_CS, BOARDS = DATA[0], DATA[1], DATA[2]


### PR DESCRIPTION
Add python scripts for CN-0435 project.

- Add basic python scripts to read or write MODBUS registers from CN-0414 and/or CN-0418 boards.
- Add main scripts to interact via MODBUS commands with one or more CN-0414 or CN-0418 boards which compose a DCS or a PLC system.
