### PR TITLE
AD5592/3R_PMOD: Fix test mode ADC reading

### DIFF
--- a/projects/ADuCM3029_demo_ad5592r_ad5593r/src/aio_dio_pdmz.c
+++ b/projects/ADuCM3029_demo_ad5592r_ad5593r/src/aio_dio_pdmz.c
@@ -1514,6 +1514,7 @@ static inline int32_t aiodio_process_test(struct aiodio_dev *dev)
 		ret = dev->read_adc(dev->board_device, (i + 4), &analog_temp);
 		if(ret != 0)
 			return ret;
+		analog_temp &= 0xFFF;
 		min = staircase[3 - i] - test_tol;
 		max = staircase[3 - i] + test_tol;
 		if((analog_temp < min) || (analog_temp > max)) {


### PR DESCRIPTION
Reading the ADC in test mode returns 16 bits, but only the first 12 are
useful data. The application was considering all the 16 bits and the test
mode never returned positive result because of it. Mask the most
significant 4 bits of the ADC return value to fix the issue.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>