### PR TITLE
AD5592/3r_demo: add streaming command to project

### DIFF
--- a/projects/ADuCM3029_demo_ad5592r_ad5593r/src/aio_dio_pdmz.h
+++ b/projects/ADuCM3029_demo_ad5592r_ad5593r/src/aio_dio_pdmz.h
@@ -61,6 +61,9 @@
 #define HELP_SHORT_COMMAND true
 #define HELP_LONG_COMMAND false
 
+#define AD5592_3_INTERNAL_REFERENCE (float)2.5
+#define AD5592_3_RESOLUTION_BITS 12
+
 typedef int32_t (*adc_read_ptr)(struct ad5592r_dev *, uint8_t, uint16_t *);
 typedef int32_t (*dac_write_ptr)(struct ad5592r_dev *, uint8_t, uint16_t);
 
@@ -141,5 +144,8 @@ int32_t aiodio_prod_test_mode(struct aiodio_dev *dev, uint8_t *arg);
 
 /* Application process. */
 int32_t aiodio_process(struct aiodio_dev *dev);
+
+/* Stream input data from the ADC inputs. */
+int32_t aiodio_analog_in_stream(struct aiodio_dev *dev, uint8_t *arg);
 
 #endif /* AIO_DIO_PDMZ_H_ */


### PR DESCRIPTION
This patch adds a ADC streaming option that reads the ADC input
continuously from all channels. If the channel is not setup as ADC it shows
an appropriate message.

Signed-off-by: Drimbarean <Andrei.Drimbarean@analog.com>