### PR TITLE
cn0401_demo: fix receive function bug

### DIFF
--- a/projects/ADuCM3029_demo_cn0401/src/can_obj_layer.c
+++ b/projects/ADuCM3029_demo_cn0401/src/can_obj_layer.c
@@ -590,9 +590,9 @@ int32_t can_ctrl_get_rec_message(struct can_ctrl_dev *dev, uint8_t fifo_nr,
 	payload_size = can_ctrl_dlc_to_size(obj.hdr_str.dlc);
 
 	if(fifo_con & FIFOCON_RXTSEN_MASK)
-		memcpy(data, (msg_buff + 12), payload_size);
+		memcpy(data, ((uint8_t *)msg_buff) + 12, payload_size);
 	else
-		memcpy(data, (msg_buff + 8), payload_size);
+		memcpy(data, ((uint8_t *)msg_buff) + 8, payload_size);
 	free(msg_buff);
 
 	fifo_con &= ~FIFOCON_UINC_MODE(WORD_MASK);


### PR DESCRIPTION
Cast object layer data pointer to (uint8_t *) before incrementing it
past the message header to ensure correct incrementation (12 and 8
bytes, respectively, instead of 48 and 32).

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>