### PR TITLE
projects:ad7124_8pmdz: fix CLI buffer drop

### DIFF
--- a/projects/ADuCM3029_demo_ad7124_8PMDZ/src/cli.c
+++ b/projects/ADuCM3029_demo_ad7124_8PMDZ/src/cli.c
@@ -111,6 +111,9 @@ void cli_uart_callback(void *app_param, uint32_t event,
 		cli_parse(cli_ptr, uart_buff);
 		uart_read_nonblocking(cli_ptr->uart_device, &uart_buff, 1);
 		break;
+	case ERROR:
+		uart_read_nonblocking(cli_ptr->uart_device, &uart_buff, 1);
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
When large streams of data were read from the device UART read buffer sometimes
dropped. If the buffer is dropped, add another.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>