### PR TITLE
Build_projects.yml: Create file for pipeline to build projects

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -1,0 +1,27 @@
+trigger:
+- master
+- dev/*
+
+pr:
+- master
+
+variables:
+- group: noos_releases_group_variables
+
+jobs:
+- job: Projects
+  pool: LocalPool
+  steps:
+  - checkout: self
+    fetchDepth: 50
+    #Add recursive when noos ready
+    submodules: false
+    clean: true
+    persistCredentials: true
+  - script: 'python ./build_projects.py $(Build.Repository.LocalPath) $(RELEASE_DIR)'
+    displayName: 'Run projects build'
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: '$(Build.Repository.LocalPath)/$(RELEASE_DIR).zip'
+      artifact: '$(ARTIFACT_NAME)'
+      publishLocation: 'pipeline'


### PR DESCRIPTION
A build will be triggered for new commits on master or dev/*
branches an on PR to main.
A self hosted pool will be used to run this pipelene.
Binaries will be build by calling build_projects.py.
Output files will be exported as an artifcat.
Variables as RELEASE_DIR and ARTIFACT_NAME are defined in the
variable group noos_releases_group_variables inside Azure in order
to be shared with the release pipeline

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>