### PR TITLE
build_projects.yml: Publish artifacts when in master branch

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -7,8 +7,8 @@ pr:
 
 variables:
 - group: adicup_releases_group_variables
-- name: isMain
-  value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+- name: isMaster
+  value: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
 
 jobs:
 - job: Projects
@@ -22,7 +22,7 @@ jobs:
   - script: 'python ./build_projects.py $(Build.Repository.LocalPath) $(RELEASE_DIR)'
     displayName: 'Run projects build'
   - task: PublishPipelineArtifact@1
-    condition: eq(variables.isMain, true)
+    condition: eq(variables.isMaster, true)
     inputs:
       targetPath: '$(Build.Repository.LocalPath)/$(RELEASE_DIR)'
       artifact: '$(ARTIFACT_NAME)'


### PR DESCRIPTION
The default branch is master so artifacts should be published on new
master commits

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>