### PR TITLE
projects:ADuCM3029_demo_cn0536: Set SAMPLING_PERIOD to 10

### DIFF
--- a/projects/ADuCM3029_demo_cn0536/app_src/geiger_counter.h
+++ b/projects/ADuCM3029_demo_cn0536/app_src/geiger_counter.h
@@ -45,7 +45,7 @@
 #include <stdint.h>
 
 /* Number of seconds between each measurement */
-#define SAMPLING_PERIOD		5//seconds
+#define SAMPLING_PERIOD		10//seconds
 /* Number of measurements used for average filtering */
 #define NB_AVARGE_SAMPLES	5
 /* Conversion factor from counts/minute -> microSieverts/minute */


### PR DESCRIPTION
5 was used only for faster debugging. 10 seconds is the correct
value.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>