### PR TITLE
cn0503: add ADPD4100 support

### DIFF
--- a/projects/ADuCM3029_demo_cn0503/.cproject
+++ b/projects/ADuCM3029_demo_cn0503/.cproject
@@ -34,7 +34,7 @@
 								</option>
 								<option id="arm.assembler.option.additionaldirectories.1941070183" name="Additional include directories (-I):" superClass="arm.assembler.option.additionaldirectories" useByScannerDiscovery="false" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/system}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.6.0/CMSIS/Core/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.7.0/CMSIS/Core/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/dma&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/flash&quot;"/>
@@ -70,7 +70,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/system}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/ADuCM3029_demo_cn0503/src/platform_include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/ADuCM3029_demo_cn0503/src/platform_source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.6.0/CMSIS/Core/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.7.0/CMSIS/Core/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/dma&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/flash&quot;"/>
@@ -100,7 +100,7 @@
 									<listOptionValue builtIn="false" value="__SILICON_REVISION__=0x102"/>
 								</option>
 								<option id="arm.linker.option.include.paths.1779351548" name="Additional include directories (-I):" superClass="arm.linker.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.6.0/CMSIS/Core/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.7.0/CMSIS/Core/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/dma&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/flash&quot;"/>
@@ -137,7 +137,7 @@
 								</option>
 								<option id="arm.toolchain.cpp.compiler.option.coreid.914475424" name="Specify the core Id (-DCORE[A|B|0-2])" superClass="arm.toolchain.cpp.compiler.option.coreid" value="0" valueType="string"/>
 								<option id="arm.base.compiler.option.include.paths.656562997" name="Additional include directories (-I):" superClass="arm.base.compiler.option.include.paths" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.6.0/CMSIS/Core/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.7.0/CMSIS/Core/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/dma&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/flash&quot;"/>
@@ -164,7 +164,7 @@
 									<listOptionValue builtIn="false" value="__SILICON_REVISION__=0x102"/>
 								</option>
 								<option id="arm.linker.option.include.paths.2052160279" name="Additional include directories (-I):" superClass="arm.linker.option.include.paths" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.6.0/CMSIS/Core/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.7.0/CMSIS/Core/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/dma&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/flash&quot;"/>
@@ -251,7 +251,7 @@
 								</option>
 								<option id="arm.assembler.option.additionaldirectories.1830773105" name="Additional include directories (-I):" superClass="arm.assembler.option.additionaldirectories" valueType="includePath">
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/system}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.6.0/CMSIS/Core/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.7.0/CMSIS/Core/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/dma&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/flash&quot;"/>
@@ -287,7 +287,7 @@
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/${ProjName}/system}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/ADuCM3029_demo_cn0503/src/platform_include}&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${workspace_loc:/ADuCM3029_demo_cn0503/src/platform_source}&quot;"/>
-									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.6.0/CMSIS/Core/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.7.0/CMSIS/Core/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/dma&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/flash&quot;"/>
@@ -316,7 +316,7 @@
 									<listOptionValue builtIn="false" value="__SILICON_REVISION__=0x102"/>
 								</option>
 								<option id="arm.linker.option.include.paths.2087525320" name="Additional include directories (-I):" superClass="arm.linker.option.include.paths" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.6.0/CMSIS/Core/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.7.0/CMSIS/Core/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/dma&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/flash&quot;"/>
@@ -353,7 +353,7 @@
 								</option>
 								<option id="arm.toolchain.cpp.compiler.option.coreid.963311174" name="Specify the core Id (-DCORE[A|B|0-2])" superClass="arm.toolchain.cpp.compiler.option.coreid" value="0" valueType="string"/>
 								<option id="arm.base.compiler.option.include.paths.309240827" name="Additional include directories (-I):" superClass="arm.base.compiler.option.include.paths" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.6.0/CMSIS/Core/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.7.0/CMSIS/Core/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/dma&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/flash&quot;"/>
@@ -380,7 +380,7 @@
 									<listOptionValue builtIn="false" value="__SILICON_REVISION__=0x102"/>
 								</option>
 								<option id="arm.linker.option.include.paths.1465783459" name="Additional include directories (-I):" superClass="arm.linker.option.include.paths" valueType="includePath">
-									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.6.0/CMSIS/Core/Include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/ARM/CMSIS/5.7.0/CMSIS/Core/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/dma&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${cmsis_pack_root}/AnalogDevices/ADuCM302x_DFP/3.2.0/Include/drivers/flash&quot;"/>

--- a/projects/ADuCM3029_demo_cn0503/src/adpd410x.c
+++ b/projects/ADuCM3029_demo_cn0503/src/adpd410x.c
@@ -111,7 +111,7 @@ int32_t adpd410x_reg_write(struct adpd410x_dev *dev, uint16_t address,
 	switch (dev->dev_type) {
 	case ADPD4100:
 		buff[0] = field_get(ADPD410X_UPPDER_BYTE_SPI_MASK, address);
-		buff[1] = (address << 1) & ADPD410X_LOWER_BYTE_SPI_MASK;
+		buff[1] = ((address << 1) & ADPD410X_LOWER_BYTE_SPI_MASK) | 0x1;
 		buff[2] = field_get(0xff00, data);
 		buff[3] = data & 0xff;
 

--- a/projects/ADuCM3029_demo_cn0503/src/adpd410x.h
+++ b/projects/ADuCM3029_demo_cn0503/src/adpd410x.h
@@ -1214,13 +1214,25 @@ int32_t adpd410x_reset(struct adpd410x_dev *dev);
 int32_t adpd410x_set_opmode(struct adpd410x_dev *dev,
 			    enum adpd410x_opmode mode);
 
+/** Get operation mode. */
+int32_t adpd410x_get_opmode(struct adpd410x_dev *dev,
+			    enum adpd410x_opmode *mode);
+
 /** Set number of active time slots. */
 int32_t adpd410x_set_last_timeslot(struct adpd410x_dev *dev,
 				   uint8_t timeslot_no);
 
+/** Get number of active time slots. */
+int32_t adpd410x_get_last_timeslot(struct adpd410x_dev *dev,
+				   enum adpd410x_timeslots *timeslot_no);
+
 /** Set device sampling frequency. */
 int32_t adpd410x_set_sampling_freq(struct adpd410x_dev *dev,
 				   uint32_t sampling_freq);
+
+/** Get device sampling frequency. */
+int32_t adpd410x_get_sampling_freq(struct adpd410x_dev *dev,
+				   uint32_t *sampling_freq);
 
 /** Setup an active time slot. */
 int32_t adpd410x_timeslot_setup(struct adpd410x_dev *dev,

--- a/projects/ADuCM3029_demo_cn0503/src/app_config.h
+++ b/projects/ADuCM3029_demo_cn0503/src/app_config.h
@@ -1,0 +1,45 @@
+/***************************************************************************//**
+ *   @file   app_config.h
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef APP_CONFIG_H_
+#define APP_CONFIG_H_
+
+//#define ADPD4100_SUPPORT
+//#define ADPD4101_SUPPORT
+
+#endif // APP_CONFIG_H_
+

--- a/projects/ADuCM3029_demo_cn0503/src/cn0503.c
+++ b/projects/ADuCM3029_demo_cn0503/src/cn0503.c
@@ -54,6 +54,8 @@
 #include "uart_extra.h"
 #include "power.h"
 #include "irq_extra.h"
+#include "spi_extra.h"
+#include "app_config.h"
 
 /******************************************************************************/
 /************************** Variable Definitions ******************************/
@@ -3938,19 +3940,41 @@ void cn0503_get_config(struct cn0503_init_param *init_param)
 {
 	struct aducm_uart_init_param *aducm_uart_ini;
 
+#ifdef ADPD4100_SUPPORT
+	struct aducm_spi_init_param aducm_spi_init = {
+		.continuous_mode = true,
+		.dma = false,
+		.half_duplex = false,
+		.master_mode = MASTER,
+		.spi_channel = SPI0
+	};
+#endif
+
 	aducm_uart_ini = init_param->cli_param.uart_init.extra;
 	aducm_uart_ini->parity = UART_NO_PARITY;
 	aducm_uart_ini->stop_bits = UART_ONE_STOPBIT;
 	aducm_uart_ini->word_length = UART_WORDLEN_8BITS;
 
+#ifdef ADPD4100_SUPPORT
+	init_param->adpd4100_param.dev_ops_init.spi_phy_init.extra = &aducm_spi_init;
+	init_param->adpd4100_param.dev_ops_init.spi_phy_init.max_speed_hz = 1000000;
+	init_param->adpd4100_param.dev_ops_init.spi_phy_init.chip_select = 1;
+	init_param->adpd4100_param.dev_ops_init.spi_phy_init.mode = SPI_MODE_0;
+	init_param->adpd4100_param.dev_type = ADPD4100;
+#else
 	init_param->adpd4100_param.dev_ops_init.i2c_phy_init.extra = NULL;
 	init_param->adpd4100_param.dev_ops_init.i2c_phy_init.max_speed_hz = 400000;
 	init_param->adpd4100_param.dev_ops_init.i2c_phy_init.slave_address = 0x24;
 	init_param->adpd4100_param.dev_type = ADPD4101;
+#endif
 
 	init_param->adpd4100_param.clk_opt = ADPD410X_INTLFO_INTHFO;
 	init_param->adpd4100_param.ext_lfo_freq = 0;
+#ifdef ADPD4100_SUPPORT
+	init_param->adpd4100_param.gpio0.number = 0x08;
+#else
 	init_param->adpd4100_param.gpio0.number = 0x0F;
+#endif
 	init_param->adpd4100_param.gpio0.extra = NULL;
 	init_param->adpd4100_param.gpio1.number = 0x0D;
 	init_param->adpd4100_param.gpio1.extra = NULL;

--- a/projects/ADuCM3029_demo_cn0503/system.svc
+++ b/projects/ADuCM3029_demo_cn0503/system.svc
@@ -9,6 +9,12 @@
 	<configurations>
 		<configuration id="com.analog.crosscore.ssldd.pinmux.component">
 			<pinmux-configuration processor="ADuCM3029" version="1.0">
+				<peripheral description="SPI0 Module" name="SPI0">
+					<signal bit="0" mux="1" name="SCLK" pin="0" port="P0"/>
+					<signal bit="2" mux="1" name="MOSI" pin="1" port="P0"/>
+					<signal bit="4" mux="1" name="MISO" pin="2" port="P0"/>
+					<signal bit="20" mux="1" name="CS_1" pin="10" port="P1"/>
+				</peripheral>
 				<peripheral description="I2C0 Module" name="I2C0">
 					<signal bit="8" mux="1" name="SCL0" pin="4" port="P0"/>
 					<signal bit="10" mux="1" name="SDA0" pin="5" port="P0"/>
@@ -18,10 +24,16 @@
 					<signal bit="22" mux="1" name="Rx" pin="11" port="P0"/>
 				</peripheral>
 				<gpio name="P0">
+					<signal bit="0" name="P0_00" pin="0" port="P0"/>
+					<signal bit="2" name="P0_01" pin="1" port="P0"/>
+					<signal bit="4" name="P0_02" pin="2" port="P0"/>
 					<signal bit="8" name="P0_04" pin="4" port="P0"/>
 					<signal bit="10" name="P0_05" pin="5" port="P0"/>
 					<signal bit="20" name="P0_10" pin="10" port="P0"/>
 					<signal bit="22" name="P0_11" pin="11" port="P0"/>
+				</gpio>
+				<gpio name="P1">
+					<signal bit="20" name="P1_10" pin="10" port="P1"/>
 				</gpio>
 			</pinmux-configuration>
 		</configuration>

--- a/projects/ADuCM3029_demo_cn0503/system/pinmux/GeneratedSources/pinmux_config.c
+++ b/projects/ADuCM3029_demo_cn0503/system/pinmux/GeneratedSources/pinmux_config.c
@@ -1,8 +1,8 @@
 /*
  **
- ** Source file generated on October 15, 2019 at 16:08:22.	
+ ** Source file generated on August 2, 2021 at 11:30:30.	
  **
- ** Copyright (C) 2011-2019 Analog Devices Inc., All Rights Reserved.
+ ** Copyright (C) 2011-2021 Analog Devices Inc., All Rights Reserved.
  **
  ** This file is generated automatically based upon the options selected in 
  ** the Pin Multiplexing configuration editor. Changes to the Pin Multiplexing
@@ -11,17 +11,22 @@
  **
  ** Selected Peripherals
  ** --------------------
+ ** SPI0 (SCLK, MOSI, MISO, CS_1)
  ** I2C0 (SCL0, SDA0)
  ** UART0 (Tx, Rx)
  **
  ** GPIO (unavailable)
  ** ------------------
- ** P0_04, P0_05, P0_10, P0_11
+ ** P0_00, P0_01, P0_02, P0_04, P0_05, P0_10, P0_11, P1_10
  */
 
 #include <sys/platform.h>
 #include <stdint.h>
 
+#define SPI0_SCLK_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<0))
+#define SPI0_MOSI_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<2))
+#define SPI0_MISO_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<4))
+#define SPI0_CS_1_PORTP1_MUX  ((uint32_t) ((uint32_t) 1<<20))
 #define I2C0_SCL0_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<8))
 #define I2C0_SDA0_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<10))
 #define UART0_TX_PORTP0_MUX  ((uint32_t) ((uint32_t) 1<<20))
@@ -34,8 +39,10 @@ int32_t adi_initpinmux(void);
  */
 int32_t adi_initpinmux(void) {
     /* PORTx_MUX registers */
-    *((volatile uint32_t *)REG_GPIO0_CFG) = I2C0_SCL0_PORTP0_MUX | I2C0_SDA0_PORTP0_MUX
+    *((volatile uint32_t *)REG_GPIO0_CFG) = SPI0_SCLK_PORTP0_MUX | SPI0_MOSI_PORTP0_MUX
+     | SPI0_MISO_PORTP0_MUX | I2C0_SCL0_PORTP0_MUX | I2C0_SDA0_PORTP0_MUX
      | UART0_TX_PORTP0_MUX | UART0_RX_PORTP0_MUX;
+    *((volatile uint32_t *)REG_GPIO1_CFG) = SPI0_CS_1_PORTP1_MUX;
 
     return 0;
 }


### PR DESCRIPTION
Add support for the ADPD4100 device which works using the SPI protocol.

Current version offers support only for I2C communication. 

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>