### PR TITLE
cn0567: initial implementation

### DIFF
--- a/projects/ADuCM3029_demo_cn0567/Makefile
+++ b/projects/ADuCM3029_demo_cn0567/Makefile
@@ -1,0 +1,9 @@
+NO-OS=$(realpath ../../no-OS)
+
+PLATFORM=aducm3029
+
+include ../../no-OS/tools/scripts/generic_variables.mk
+
+include src.mk
+
+include $(NO-OS)/tools/scripts/generic.mk

--- a/projects/ADuCM3029_demo_cn0567/README.md
+++ b/projects/ADuCM3029_demo_cn0567/README.md
@@ -1,0 +1,1 @@
+This is a demo project for the EVAL-CN0567-ARDZ Shield.

--- a/projects/ADuCM3029_demo_cn0567/builds.json
+++ b/projects/ADuCM3029_demo_cn0567/builds.json
@@ -1,0 +1,4 @@
+{
+    "demo_adpd4100": "NEW_CFLAGS=-DADPD4100_SUPPORT",
+    "demo_adpd4101": "NEW_CFLAGS=-DADPD4101_SUPPORT"
+}

--- a/projects/ADuCM3029_demo_cn0567/pinmux_config.c
+++ b/projects/ADuCM3029_demo_cn0567/pinmux_config.c
@@ -1,0 +1,54 @@
+/*
+ **
+ ** Source file generated on August 26, 2021 at 12:18:36.	
+ **
+ ** Copyright (C) 2011-2021 Analog Devices Inc., All Rights Reserved.
+ **
+ ** This file is generated automatically based upon the options selected in 
+ ** the Pin Multiplexing configuration editor. Changes to the Pin Multiplexing
+ ** configuration should be made by changing the appropriate options rather
+ ** than editing this file.
+ **
+ ** Selected Peripherals
+ ** --------------------
+ ** SPI0 (SCLK, MOSI, MISO, CS_0, CS_1, CS_2, CS_3, RDY)
+ ** I2C0 (SCL0, SDA0)
+ ** UART0 (Tx, Rx)
+ **
+ ** GPIO (unavailable)
+ ** ------------------
+ ** P0_00, P0_01, P0_02, P0_03, P0_04, P0_05, P0_10, P0_11, P1_10, P1_14, P2_08, P2_09
+ */
+
+#include <sys/platform.h>
+#include <stdint.h>
+
+#define SPI0_SCLK_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<0))
+#define SPI0_MOSI_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<2))
+#define SPI0_MISO_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<4))
+#define SPI0_CS_0_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<6))
+#define SPI0_CS_1_PORTP1_MUX  ((uint32_t) ((uint32_t) 1<<20))
+#define SPI0_CS_2_PORTP2_MUX  ((uint32_t) ((uint32_t) 2<<16))
+#define SPI0_CS_3_PORTP2_MUX  ((uint32_t) ((uint32_t) 2<<18))
+#define SPI0_RDY_PORTP1_MUX  ((uint32_t) ((uint32_t) 2<<28))
+#define I2C0_SCL0_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<8))
+#define I2C0_SDA0_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<10))
+#define UART0_TX_PORTP0_MUX  ((uint32_t) ((uint32_t) 1<<20))
+#define UART0_RX_PORTP0_MUX  ((uint32_t) ((uint32_t) 1<<22))
+
+int32_t adi_initpinmux(void);
+
+/*
+ * Initialize the Port Control MUX Registers
+ */
+int32_t adi_initpinmux(void) {
+    /* PORTx_MUX registers */
+    *((volatile uint32_t *)REG_GPIO0_CFG) = SPI0_SCLK_PORTP0_MUX | SPI0_MOSI_PORTP0_MUX
+     | SPI0_MISO_PORTP0_MUX | SPI0_CS_0_PORTP0_MUX | I2C0_SCL0_PORTP0_MUX
+     | I2C0_SDA0_PORTP0_MUX | UART0_TX_PORTP0_MUX | UART0_RX_PORTP0_MUX;
+    *((volatile uint32_t *)REG_GPIO1_CFG) = SPI0_CS_1_PORTP1_MUX | SPI0_RDY_PORTP1_MUX;
+    *((volatile uint32_t *)REG_GPIO2_CFG) = SPI0_CS_2_PORTP2_MUX | SPI0_CS_3_PORTP2_MUX;
+
+    return 0;
+}
+

--- a/projects/ADuCM3029_demo_cn0567/src.mk
+++ b/projects/ADuCM3029_demo_cn0567/src.mk
@@ -1,0 +1,14 @@
+SRC_DIRS += $(PROJECT)/src
+SRC_DIRS += $(NO-OS)/iio/iio_app
+
+SRC_DIRS += $(PLATFORM_DRIVERS)
+SRC_DIRS += $(INCLUDE)
+SRC_DIRS += $(DRIVERS)/photo-electronic/adpd410x
+
+SRCS += $(NO-OS)/util/list.c
+SRCS += $(NO-OS)/util/util.c
+
+IGNORED_FILES += $(PLATFORM_DRIVERS)/uart_stdio.c
+IGNORED_FILES += $(PLATFORM_DRIVERS)/uart_stdio.h
+
+TINYIIOD=y

--- a/projects/ADuCM3029_demo_cn0567/src/ADuCM3029_demo_cn0567.c
+++ b/projects/ADuCM3029_demo_cn0567/src/ADuCM3029_demo_cn0567.c
@@ -1,0 +1,76 @@
+/***************************************************************************//**
+ *   @file   ADuCM3029_demo_cn0567.c
+ *   @brief  Main Application.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <sys/platform.h>
+#include <stdint.h>
+#include "adi_initialize.h"
+
+#include "cn0567.h"
+#include "error.h"
+#include "iio_adpd410x.h"
+#include "iio_app.h"
+#include "util.h"
+
+int main(int argc, char *argv[])
+{
+	int32_t ret;
+	struct cn0567_dev *cn0567;
+	uint32_t data[8];
+
+	ret = platform_init();
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	ret = cn0567_init(&cn0567);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	struct iio_app_device devices[] = {
+		IIO_APP_DEVICE("adpd410x", cn0567->adpd4100_handler,
+			       &adpd410x_iio_descriptor,
+			       NULL, NULL),
+	};
+
+	return iio_app_run(devices, ARRAY_SIZE(devices));
+
+	return 0;
+}

--- a/projects/ADuCM3029_demo_cn0567/src/app_config.h
+++ b/projects/ADuCM3029_demo_cn0567/src/app_config.h
@@ -1,0 +1,47 @@
+/***************************************************************************//**
+ *   @file   app_config.h
+ *   @brief  Application Configuration file.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef APP_CONFIG_H_
+#define APP_CONFIG_H_
+
+/** Choose between ADPD4100/ADPD410x support */
+//#define ADPD4100_SUPPORT
+//#define ADPD4101_SUPPORT
+
+#endif // APP_CONFIG_H_
+

--- a/projects/ADuCM3029_demo_cn0567/src/cn0567.c
+++ b/projects/ADuCM3029_demo_cn0567/src/cn0567.c
@@ -1,0 +1,442 @@
+/***************************************************************************//**
+ *   @file   cn0567.c
+ *   @brief  CN0567 Source file
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "cn0567.h"
+#include "cn0567_config.h"
+#include "error.h"
+#include "gpio.h"
+#include "delay.h"
+#include "util.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Set device to get timestamp for low frequency oscillator calibration.
+ * @param [in] dev - The device structure.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+static int32_t cn0567_calibrate_lfo_set_ts(struct cn0567_dev *dev)
+{
+	int32_t ret;
+	uint16_t reg_data;
+
+	/** Enable clock calibration circuitry */
+	if(dev->chip_id == 0x02c2) {
+		ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_OSC1M,
+					&reg_data);
+		if (IS_ERR_VALUE(ret))
+			return ret;
+		reg_data |= BITM_OSC1M_OSC_CLK_CAL_ENA;
+		ret = adpd410x_reg_write(dev->adpd4100_handler, ADPD410X_REG_OSC1M,
+					 reg_data);
+	}
+
+	/** Enable GPIO0 input */
+	ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_GPIO_CFG,
+				&reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	reg_data |= (1 & BITM_GPIO_CFG_GPIO_PIN_CFG0);
+
+	ret = adpd410x_reg_write(dev->adpd4100_handler, ADPD410X_REG_GPIO_CFG,
+				 reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	/** Enable GPIO0 as time stamp input */
+	ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_GPIO_EXT,
+				&reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	reg_data |= ((0 << BITP_GPIO_EXT_TIMESTAMP_GPIO) &
+		     BITM_GPIO_EXT_TIMESTAMP_GPIO);
+
+	return adpd410x_reg_write(dev->adpd4100_handler, ADPD410X_REG_GPIO_EXT,
+				  reg_data);
+}
+
+/**
+ * @brief Get time stamp for low frequency oscillator calibration.
+ * @param [in] dev - The device structure.
+ * @param [out] ts_val - Pointer to the timestamp value container.
+ * @param [in] ts_gpio - Descriptor for the counter start/stop GPIO.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+static int32_t cn0567_calibrate_lfo_get_timestamp(struct cn0567_dev *dev,
+		uint32_t *ts_val, struct gpio_desc *ts_gpio)
+{
+	int32_t ret;
+	uint16_t reg_data;
+
+	/** Start time stamp calibration */
+	ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_OSC32K,
+				&reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	reg_data |= BITM_OSC32K_CAPTURE_TIMESTAMP;
+	ret = adpd410x_reg_write(dev->adpd4100_handler, ADPD410X_REG_OSC32K,
+				 reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	/** Give first time stamp trigger */
+	ret = gpio_set_value(ts_gpio, GPIO_HIGH);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	mdelay(1);
+	ret = gpio_set_value(ts_gpio, GPIO_LOW);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	/** Start time stamp calibration */
+	ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_OSC32K,
+				&reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	reg_data |= BITM_OSC32K_CAPTURE_TIMESTAMP;
+	ret = adpd410x_reg_write(dev->adpd4100_handler, ADPD410X_REG_OSC32K,
+				 reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	mdelay(10);
+
+	ret = gpio_set_value(ts_gpio, GPIO_HIGH);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	mdelay(1);
+
+	ret = gpio_set_value(ts_gpio, GPIO_LOW);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_OSC32K,
+				&reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	if(reg_data & BITM_OSC32K_CAPTURE_TIMESTAMP)
+		return ret;
+
+	ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_STAMP_H,
+				&reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	*ts_val = (reg_data << 16) & 0xFFFF0000;
+
+	ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_STAMP_L,
+				&reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	*ts_val |= reg_data;
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Do low frequency oscillator calibration with respect to an external
+ *        reference.
+ * @param [in] dev - The device structure.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+static int32_t cn0567_calibrate_lfo(struct cn0567_dev *dev)
+{
+	int32_t ret;
+	uint32_t ts_val_current, ts_val_last = 0, ts_val;
+	uint16_t reg_data, cal_value;
+	int8_t rdy = 0;
+	struct gpio_desc *ts_gpio;
+	struct gpio_init_param ts_param;
+
+	ret = cn0567_calibrate_lfo_set_ts(dev);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	/** Setup platform GPIO for time stamp trigger */
+	ts_param.number = 15;
+	ts_param.extra = NULL;
+
+	ret = gpio_get(&ts_gpio, &ts_param);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	ret = gpio_direction_output(ts_gpio, GPIO_LOW);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	/** Delay to correctly initialize GPIO circuitry in device. */
+	mdelay(1);
+
+	while (1) {
+		ret = cn0567_calibrate_lfo_get_timestamp(dev, &ts_val_current,
+				ts_gpio);
+		if (IS_ERR_VALUE(ret))
+			return ret;
+
+		if(ts_val_current < ts_val_last) {
+			ts_val_last = 0;
+			continue;
+		}
+		ts_val = ts_val_current - ts_val_last;
+		ts_val_last = ts_val_current;
+
+		ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_OSC1M,
+					&reg_data);
+		if (IS_ERR_VALUE(ret))
+			return ret;
+
+		cal_value = reg_data & BITM_OSC1M_OSC_1M_FREQ_ADJ;
+		if(ts_val < (10000 - (10000 * 0.005)))
+			cal_value++;
+		else if(ts_val > (10000 + (10000 * 0.005)))
+			cal_value--;
+		else
+			rdy = 1;
+		if(rdy == 1)
+			break;
+		if((cal_value == 0) || (cal_value == BITM_OSC1M_OSC_1M_FREQ_ADJ))
+			break;
+
+		reg_data &= ~BITM_OSC1M_OSC_1M_FREQ_ADJ;
+		reg_data |= cal_value & BITM_OSC1M_OSC_1M_FREQ_ADJ;
+
+		ret = adpd410x_reg_write(dev->adpd4100_handler, ADPD410X_REG_OSC1M,
+					 reg_data);
+		if (IS_ERR_VALUE(ret))
+			return ret;
+	};
+
+	ret = gpio_remove(ts_gpio);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	if(rdy == 1)
+		return SUCCESS;
+	else
+		return ret;
+}
+
+/**
+ * @brief Do high frequency oscillator calibration with respect to the low
+ *        frequency oscillator.
+ * @param [in] dev - The device structure.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t cn0567_calibrate_hfo(struct cn0567_dev *dev)
+{
+	int32_t ret;
+	uint16_t reg_data;
+
+	ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_OSC32M_CAL,
+				&reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	reg_data |= BITM_OSC32M_CAL_OSC_32M_CAL_START;
+
+	do {
+		ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_OSC32M_CAL,
+					&reg_data);
+		if (IS_ERR_VALUE(ret))
+			return ret;
+	} while(reg_data & BITM_OSC32M_CAL_OSC_32M_CAL_START);
+
+	/** Disable clock calibration circuitry */
+	ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_OSC1M,
+				&reg_data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	reg_data &= ~BITM_OSC1M_OSC_CLK_CAL_ENA;
+
+	return adpd410x_reg_write(dev->adpd4100_handler, ADPD410X_REG_OSC1M,
+				  reg_data);
+}
+
+/**
+ * @brief Initial process of the application.
+ * @param [out] device - Pointer to the application handler.
+ * @param [in] init_param - Pointer to the application initialization structure.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t cn0567_init(struct cn0567_dev **device)
+{
+	int32_t ret;
+	struct cn0567_dev *dev;
+	int8_t i;
+	uint16_t data;
+
+	dev = (struct cn0567_dev *)calloc(1, sizeof *dev);
+	if(!dev)
+		return FAILURE;
+
+	ret = adpd410x_setup(&dev->adpd4100_handler,
+			     &adpd4100_param);
+	if (IS_ERR_VALUE(ret))
+		goto error_cn;
+
+	ret = adpd410x_reg_read(dev->adpd4100_handler, ADPD410X_REG_CHIP_ID,
+				&dev->chip_id);
+	if (IS_ERR_VALUE(ret))
+		goto error_cn;
+
+	ret = adpd410x_set_sampling_freq(dev->adpd4100_handler,
+					 CN0567_CODE_ODR_DEFAULT);
+	if (IS_ERR_VALUE(ret))
+		goto error_cn;
+
+	ret = adpd410x_set_last_timeslot(dev->adpd4100_handler,
+					 ADPD410X_ACTIVE_TIMESLOTS - 1);
+	if (IS_ERR_VALUE(ret))
+		goto error_cn;
+
+	for (i = 0; i < ADPD410X_ACTIVE_TIMESLOTS; i++) {
+		ret = adpd410x_timeslot_setup(dev->adpd4100_handler, i,
+					      ts_init_tab + i);
+		if (IS_ERR_VALUE(ret))
+			goto error_cn;
+
+		/** Precondition VC1 and VC2 to TIA_VREF+250mV */
+		ret = adpd410x_reg_read(dev->adpd4100_handler,
+					ADPD410X_REG_CATHODE(i), &data);
+		if (IS_ERR_VALUE(ret))
+			goto error_cn;
+		data &= ~(BITM_CATHODE_A_VC2_SEL | BITM_CATHODE_A_VC1_SEL);
+		data |= (2 << BITP_CATHODE_A_VC2_SEL) & BITM_CATHODE_A_VC2_SEL;
+		data |= (2 << BITP_CATHODE_A_VC1_SEL) & BITM_CATHODE_A_VC1_SEL;
+		ret = adpd410x_reg_write(dev->adpd4100_handler,
+					 ADPD410X_REG_CATHODE(i), data);
+		if (IS_ERR_VALUE(ret))
+			goto error_cn;
+
+		/** Set the two channels trim option */
+		ret = adpd410x_reg_read(dev->adpd4100_handler,
+					ADPD410X_REG_AFE_TRIM(i), &data);
+		if (IS_ERR_VALUE(ret))
+			goto error_cn;
+		data |= (1 << BITP_AFE_TRIM_A_CH1_TRIM_INT |
+			 1 << BITP_AFE_TRIM_A_CH2_TRIM_INT);
+		ret = adpd410x_reg_write(dev->adpd4100_handler,
+					 ADPD410X_REG_AFE_TRIM(i), data);
+		if (IS_ERR_VALUE(ret))
+			goto error_cn;
+
+		/**
+		 * Set to ~32us integrator offset to line up zero crossing of
+		 * BPF
+		 */
+		ret = adpd410x_reg_read(dev->adpd4100_handler,
+					ADPD410X_REG_INTEG_OFFSET(i),
+					&data);
+		if (IS_ERR_VALUE(ret))
+			goto error_cn;
+		data = 0x03FC & BITM_INTEG_OFFSET_A_INTEG_OFFSET;
+		ret = adpd410x_reg_write(dev->adpd4100_handler,
+					 ADPD410X_REG_INTEG_OFFSET(i), data);
+		if (IS_ERR_VALUE(ret))
+			goto error_cn;
+
+		/** Set to ~32us LED offset */
+		ret = adpd410x_reg_read(dev->adpd4100_handler,
+					ADPD410X_REG_LED_PULSE(i), &data);
+		if (IS_ERR_VALUE(ret))
+			goto error_cn;
+		data = 0x0220;
+		ret = adpd410x_reg_write(dev->adpd4100_handler,
+					 ADPD410X_REG_LED_PULSE(i), data);
+		if (IS_ERR_VALUE(ret))
+			goto error_cn;
+	}
+
+	ret = cn0567_calibrate_lfo(dev);
+	if (IS_ERR_VALUE(ret))
+		goto error_cn;
+
+	ret = cn0567_calibrate_hfo(dev);
+	if (IS_ERR_VALUE(ret))
+		goto error_cn;
+
+	for (i = 0; i < 63; i++) {
+		ret = adpd410x_reg_write(dev->adpd4100_handler, reg_config_default[i][0],
+					 reg_config_default[i][1]);
+		if (IS_ERR_VALUE(ret))
+			return ret;
+	}
+
+	*device = dev;
+
+	return ret;
+
+error_cn:
+	free(dev);
+
+	return FAILURE;
+}
+
+/**
+ * @brief Free memory allocated by cn0567_init().
+ * @param [in] dev - The device structure.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t cn0567_remove(struct cn0567_dev *dev)
+{
+	int32_t ret;
+
+	if(!dev)
+		return FAILURE;
+
+	ret = adpd410x_remove(dev->adpd4100_handler);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	free(dev);
+
+	return SUCCESS;
+}

--- a/projects/ADuCM3029_demo_cn0567/src/cn0567.h
+++ b/projects/ADuCM3029_demo_cn0567/src/cn0567.h
@@ -1,0 +1,75 @@
+/***************************************************************************//**
+ *   @file   cn0567.h
+ *   @brief  CN0567 Header file
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef CN0567_H_
+#define CN0567_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include "adpd410x.h"
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @struct cn0567_dev
+ * @brief Application handler structure
+ */
+struct cn0567_dev {
+	/** ADPD device handler */
+	struct adpd410x_dev *adpd4100_handler;
+	/** Chip id */
+	uint16_t chip_id;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/** Initial process of the application. */
+int32_t cn0567_init(struct cn0567_dev **device);
+
+/** Free memory allocated by cn0567_init(). */
+int32_t cn0567_remove(struct cn0567_dev *dev);
+
+#endif /* CN0567_H_ */

--- a/projects/ADuCM3029_demo_cn0567/src/cn0567_config.h
+++ b/projects/ADuCM3029_demo_cn0567/src/cn0567_config.h
@@ -1,0 +1,370 @@
+/***************************************************************************//**
+ *   @file   cn0567_config.h
+ *   @brief  CN0567 Configuration File
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef CN0567_CONFIG_H_
+#define CN0567_CONFIG_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "adpd410x.h"
+#include "app_config.h"
+#include "spi_extra.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define ADPD410X_ACTIVE_TIMESLOTS 4
+#define CN0567_CODE_ODR_DEFAULT	50
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+#ifndef ADPD4101_SUPPORT
+struct aducm_spi_init_param aducm_spi_init = {
+	.continuous_mode = true,
+	.dma = false,
+	.half_duplex = false,
+	.master_mode = MASTER,
+};
+#endif
+
+static struct adpd410x_init_param adpd4100_param = {
+#ifndef ADPD4101_SUPPORT
+	.dev_ops_init = {
+		.spi_phy_init = {
+			.device_id = 0,
+			.max_speed_hz = 1000000,
+			.chip_select = 1,
+			.mode = SPI_MODE_0,
+			.extra = &aducm_spi_init,
+			.platform_ops = NULL
+		},
+	},
+	.dev_type = ADPD4100,
+#else
+	.dev_ops_init = {
+		.i2c_phy_init = {
+			.max_speed_hz = 400000,
+			.slave_address = 0x24,
+			.extra = NULL,
+		},
+	},
+	.dev_type = ADPD4101,
+#endif
+	.clk_opt = ADPD410X_INTLFO_INTHFO,
+	.ext_lfo_freq = 0,
+	.gpio0 = {
+#ifndef ADPD4101_SUPPORT
+		.number = 0x08,
+#else
+		.number = 0x0F,
+#endif
+		.extra = NULL,
+	},
+	.gpio1 = {
+		.number = 0x0D,
+		.extra = NULL,
+	},
+	.gpio2 = {
+		.number = 0x09,
+		.extra = NULL,
+	},
+	.gpio3 = {
+		.number = 0x21,
+		.extra = NULL,
+	},
+};
+
+/* Timeslots Configuration */
+static struct adpd410x_timeslot_init ts_init_tab[] = {
+	{
+		.ts_inputs = {
+			.option = ADPD410X_INaCH1_INbCH2,
+			.pair = ADPD410X_INP12,
+		},
+		.led1 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x70,
+			},
+		},
+		.led2 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x70,
+			},
+		},
+		.led3 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led4 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.enable_ch2 = true,
+		.precon_option = ADPD410X_TIA_VREF,
+		.afe_trim_opt = ADPD410X_TIA_VREF_1V256,
+		.vref_pulse_opt = ADPD410X_TIA_VREF_1V256,
+		.chan2 = ADPD410X_TIA_VREF_50K,
+		.chan1 = ADPD410X_TIA_VREF_100K,
+		.pulse4_subtract = 0xA,
+		.pulse4_reverse = 0xA,
+		.byte_no = 3,
+		.dec_factor = 3,
+		.repeats_no = 32,
+		.adc_cycles = 1,
+	},
+	{
+		.ts_inputs = {
+			.option = ADPD410X_INaCH1_INbCH2,
+			.pair = ADPD410X_INP34,
+		},
+		.led1 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led2 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led3 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x30,
+			},
+		},
+		.led4 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.enable_ch2 = true,
+		.precon_option = ADPD410X_TIA_VREF,
+		.afe_trim_opt = ADPD410X_TIA_VREF_1V256,
+		.vref_pulse_opt = ADPD410X_TIA_VREF_1V256,
+		.chan2 = ADPD410X_TIA_VREF_50K,
+		.chan1 = ADPD410X_TIA_VREF_100K,
+		.pulse4_subtract = 0xA,
+		.pulse4_reverse = 0xA,
+		.byte_no = 3,
+		.dec_factor = 3,
+		.repeats_no = 32,
+		.adc_cycles = 1,
+	},
+	{
+		.ts_inputs = {
+			.option = ADPD410X_INaCH1_INbCH2,
+			.pair = ADPD410X_INP56,
+		},
+		.led1 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x30,
+			},
+		},
+		.led2 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x00,
+			},
+		},
+		.led3 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led4 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.enable_ch2 = true,
+		.precon_option = ADPD410X_TIA_VREF,
+		.afe_trim_opt = ADPD410X_TIA_VREF_1V256,
+		.vref_pulse_opt = ADPD410X_TIA_VREF_1V256,
+		.chan2 = ADPD410X_TIA_VREF_50K,
+		.chan1 = ADPD410X_TIA_VREF_100K,
+		.pulse4_subtract = 0xA,
+		.pulse4_reverse = 0xA,
+		.byte_no = 3,
+		.dec_factor = 3,
+		.repeats_no = 32,
+		.adc_cycles = 1,
+	},
+	{
+		.ts_inputs = {
+			.option = ADPD410X_INaCH1_INbCH2,
+			.pair = ADPD410X_INP78,
+		},
+		.led1 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led2 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led3 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x30,
+			},
+		},
+		.led4 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x00,
+			},
+		},
+		.enable_ch2 = true,
+		.precon_option = ADPD410X_TIA_VREF,
+		.afe_trim_opt = ADPD410X_TIA_VREF_1V256,
+		.vref_pulse_opt = ADPD410X_TIA_VREF_1V256,
+		.chan2 = ADPD410X_TIA_VREF_50K,
+		.chan1 = ADPD410X_TIA_VREF_100K,
+		.pulse4_subtract = 0xA,
+		.pulse4_reverse = 0xA,
+		.byte_no = 3,
+		.dec_factor = 3,
+		.repeats_no = 32,
+		.adc_cycles = 1,
+	},
+};
+
+/* Register Configuration (address + data) */
+uint16_t reg_config_default[63][2] = {
+	/** General configuration */
+	{0x000f, 0x8000},
+	{0x000f, 0x0006},
+	{0x0000, 0x0048},
+	{0x0001, 0x000f},
+	{0x000d, 0x4e20},
+	{0x000e, 0x0000},
+	{0x0010, 0x0300},
+	/** Optical path 1 */
+	{0x0102, 0x0005},
+	{0x0105, 0x7070},
+	{0x0106, 0x0000},
+	/** Optical path 2 */
+	{0x0122, 0x0050},
+	{0x0125, 0x0000},
+	{0x0126, 0x0030},
+	/** Optical path 3 */
+	{0x0142, 0x0500},
+	{0x0145, 0x80B0},
+	{0x0146, 0x0000},
+	/** Optical path 4 */
+	{0x0162, 0x5000},
+	{0x0165, 0x0000},
+	{0x0166, 0x80B0},
+	/** AFE Path */
+	{0x0101, 0x40DA},
+	{0x0121, 0x40DA},
+	{0x0141, 0x40DA},
+	{0x0161, 0x40DA},
+	/** CH2 enable */
+	{0x0100, 0x4000},
+	{0x0120, 0x4000},
+	{0x0140, 0x4000},
+	{0x0160, 0x4000},
+	/** Precondition PDs to TIA_VREF */
+	{0x0103, 0x1000},
+	{0x0123, 0x1000},
+	{0x0143, 0x1000},
+	{0x0163, 0x1000},
+	/** AFE gain */
+	{0x0104, 0x2A92},
+	{0x0124, 0x2A92},
+	{0x0144, 0x2A92},
+	{0x0164, 0x2A92},
+	/** 1 integrate for every 32 pulses */
+	{0x0107, 0x0120},
+	{0x0127, 0x0120},
+	{0x0147, 0x0120},
+	{0x0167, 0x0120},
+	/** 2us LED pulse with 32us offset */
+	{0x0109, 0x0220},
+	{0x0129, 0x0220},
+	{0x0149, 0x0220},
+	{0x0169, 0x0220},
+	/** 3us AFE width double sided */
+	{0x010A, 0x0003},
+	{0x012A, 0x0003},
+	{0x014A, 0x0003},
+	{0x016A, 0x0003},
+	/** ~32us integrator offset to line up zero crossing of BPF */
+	{0x010B, 0x03FC},
+	{0x012B, 0x03FC},
+	{0x014B, 0x03FC},
+	{0x016B, 0x03FC},
+	/** 4 pulse chop */
+	{0x010D, 0x00AA},
+	{0x012D, 0x00AA},
+	{0x014D, 0x00AA},
+	{0x016D, 0x00AA},
+	/** 2048 digital offset */
+	{0x010F, 0x8000},
+	{0x012F, 0x8000},
+	{0x014F, 0x8000},
+	{0x016F, 0x8000},
+	/** 4 byte wide data */
+	{0x0110, 0x0004},
+	{0x0130, 0x0004},
+	{0x0150, 0x0004},
+	{0x0170, 0x0004},
+};
+
+#endif /* CN0567_CONFIG_H_ */

--- a/projects/ADuCM3029_demo_cn0567/src/parameters.h
+++ b/projects/ADuCM3029_demo_cn0567/src/parameters.h
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  CN0567 Parameters Definitions.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef PARAMETERS_H_
+#define PARAMETERS_H_
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define UART_DEVICE_ID	0
+#define INTC_DEVICE_ID	0
+#define UART_IRQ_ID		ADUCM_UART_INT_ID
+#define UART_BAUDRATE	115200
+
+#endif /* PARAMETERS_H_ */


### PR DESCRIPTION
Initial version of the CN0567 project.

Provides IIO support for both versions of the reference design:
ADPD4100 and ADPD4101.

A part of the requirement is to have the device configuration separate
from the application implementation for easier usage by the customers
(timeslot configuration / register configuration). This is done via
`cn0567_config.h` file.

(The project is a compact/reworked version of CN0503 project)

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>