### PR TITLE
projects:ADuCM3029_demo_cn0536: Fix init_mqtt ret

### DIFF
--- a/projects/ADuCM3029_demo_cn0536/app_src/communication.c
+++ b/projects/ADuCM3029_demo_cn0536/app_src/communication.c
@@ -107,7 +107,7 @@ static struct mqtt_desc		*mqtt;
 static struct tcp_socket_desc	*sock;
 static struct uart_desc		*udesc;
 
-bool init_mqtt(struct mqtt_desc **desc, struct irq_ctrl_desc *idesc)
+int32_t init_mqtt(struct mqtt_desc **desc, struct irq_ctrl_desc *idesc)
 {
 	struct wifi_init_param		wifi_param;
 	struct tcp_socket_init_param	tcp_param;


### PR DESCRIPTION
Replace bool with int32_t. If FAILURE (-1) is returned
for a bool value it will be 1. Then a check with ret < 0
will fail.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>