### PR TITLE
cn0548: add support for bipolar/unipolar config

### DIFF
--- a/projects/ADuCM3029_demo_cn0548/builds.json
+++ b/projects/ADuCM3029_demo_cn0548/builds.json
@@ -1,3 +1,4 @@
 {
-    "demo": ""
+    "demo_unipolar": "NEW_CFLAGS=-DCN0548_UNIPOLAR",
+    "demo_bipolar": "NEW_CFLAGS=-DCN0548_BIPOLAR"
 }

--- a/projects/ADuCM3029_demo_cn0548/src/app_config.h
+++ b/projects/ADuCM3029_demo_cn0548/src/app_config.h
@@ -1,9 +1,8 @@
 /***************************************************************************//**
- *   @file   cn0548.c
- *   @brief  CN0548 main application.
+ *   @file   app_config.h
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
- * Copyright 2021(c) Analog Devices, Inc.
+ * Copyright 2022(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -36,70 +35,11 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
+#ifndef APP_CONFIG_H_
+#define APP_CONFIG_H_
 
-#include <sys/platform.h>
-#include "adi_initialize.h"
-#include "no-os/spi.h"
-#include "spi_extra.h"
-#include "ad7799.h"
-#include "iio_ad7799.h"
-#include "parameters.h"
-#include "no-os/error.h"
-#include "iio_app.h"
-#include "platform_init.h"
-#include "no-os/util.h"
-#include "app_config.h"
+//#define CN0548_BIPOLAR
+//#define CN0548_UNIPOLAR
 
-int main(int argc, char *argv[])
-{
+#endif // APP_CONFIG_H_
 
-	int32_t ret;
-
-	ret = platform_init();
-	if (IS_ERR_VALUE(ret))
-		return ret;
-
-	struct aducm_spi_init_param aducm_param = {
-		.continuous_mode = true,
-		.dma = false,
-		.half_duplex = false,
-		.master_mode = MASTER,
-	};
-
-	struct spi_init_param init_param = {
-		.device_id = 0,
-		.chip_select = 1,
-		.extra = &aducm_param,
-		.max_speed_hz = 1000000,
-		.mode = SPI_MODE_3,
-		.platform_ops = &aducm_spi_ops,
-	};
-
-	struct ad7799_init_param ad7799_param = {
-		.spi_init = init_param,
-		.chip_type = ID_AD7798,
-		.gain = AD7799_GAIN_1,
-#ifdef CN0548_UNIPOLAR
-		.polarity = AD7799_UNIPOLAR,
-#else
-		.polarity = AD7799_BIPOLAR,
-#endif
-		.vref_mv = 4096
-	};
-
-	struct ad7799_dev *ad7799_device;
-
-	ret = ad7799_init(&ad7799_device, &ad7799_param);
-	if (IS_ERR_VALUE(ret))
-		return ret;
-
-	struct iio_app_device devices[] = {
-		IIO_APP_DEVICE("AD7799", ad7799_device,
-			       &ad7799_iio_descriptor,
-			       NULL, NULL)
-	};
-
-	return iio_app_run(devices, ARRAY_SIZE(devices));
-
-	return 0;
-}


### PR DESCRIPTION
Add application configuration such that both bipolar and unipolar
configuration of the ADC are available in the application layer and
build process.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>