### PR TITLE
cn0567:add support for multiple configs

### DIFF
--- a/projects/ADuCM3029_demo_cn0567/builds.json
+++ b/projects/ADuCM3029_demo_cn0567/builds.json
@@ -1,4 +1,6 @@
 {
     "demo_adpd4100": "NEW_CFLAGS=-DADPD4100_SUPPORT",
-    "demo_adpd4101": "NEW_CFLAGS=-DADPD4101_SUPPORT"
+    "demo_adpd4101": "NEW_CFLAGS=-DADPD4101_SUPPORT",
+    "demo_adpd4100_waterquality": "NEW_CFLAGS=-DADPD4100_SUPPORT\\-DCN0567_DEMO_WQ",
+    "demo_adpd4101_waterquality": "NEW_CFLAGS=-DADPD4101_SUPPORT\\-DCN0567_DEMO_WQ"
 }

--- a/projects/ADuCM3029_demo_cn0567/src/app_config.h
+++ b/projects/ADuCM3029_demo_cn0567/src/app_config.h
@@ -43,5 +43,8 @@
 //#define ADPD4100_SUPPORT
 //#define ADPD4101_SUPPORT
 
+/** Choose between CN0567 Water Quality Demo */
+//#define CN0567_DEMO_WQ
+
 #endif // APP_CONFIG_H_
 

--- a/projects/ADuCM3029_demo_cn0567/src/cn0567.c
+++ b/projects/ADuCM3029_demo_cn0567/src/cn0567.c
@@ -405,7 +405,7 @@ int32_t cn0567_init(struct cn0567_dev **device)
 	if (IS_ERR_VALUE(ret))
 		goto error_cn;
 
-	for (i = 0; i < 47; i++) {
+	for (i = 0; i < ADPD410X_REG_DEFAULT_NR; i++) {
 		ret = adpd410x_reg_write(dev->adpd4100_handler, reg_config_default[i][0],
 					 reg_config_default[i][1]);
 		if (IS_ERR_VALUE(ret))

--- a/projects/ADuCM3029_demo_cn0567/src/cn0567_config.h
+++ b/projects/ADuCM3029_demo_cn0567/src/cn0567_config.h
@@ -50,7 +50,13 @@
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
+#ifndef CN0567_DEMO_WQ
 #define ADPD410X_ACTIVE_TIMESLOTS 8
+#define ADPD410X_REG_DEFAULT_NR   31
+#else
+#define ADPD410X_ACTIVE_TIMESLOTS 4
+#define ADPD410X_REG_DEFAULT_NR   13
+#endif
 #define CN0567_CODE_ODR_DEFAULT	50
 
 /******************************************************************************/
@@ -112,6 +118,7 @@ static struct adpd410x_init_param adpd4100_param = {
 	},
 };
 
+#ifndef CN0567_DEMO_WQ
 /* Timeslots Configuration */
 static struct adpd410x_timeslot_init ts_init_tab[] = {
 	{
@@ -127,19 +134,19 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		},
 		.led2 = {
 			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_A,
+				.led_output_select = ADPD410X_OUTPUT_B,
 				.let_current_select = 0x00,
 			},
 		},
 		.led3 = {
 			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_A,
+				.led_output_select = ADPD410X_OUTPUT_B,
 				.let_current_select = 0x00,
 			},
 		},
 		.led4 = {
 			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_A,
+				.led_output_select = ADPD410X_OUTPUT_B,
 				.let_current_select = 0x00,
 			},
 		},
@@ -152,8 +159,8 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		.pulse4_subtract = 0xA,
 		.pulse4_reverse = 0xA,
 		.byte_no = 3,
-		.dec_factor = 3,
-		.repeats_no = 32,
+		.dec_factor = 0,
+		.repeats_no = 1,
 		.adc_cycles = 1,
 	},
 	{
@@ -194,8 +201,8 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		.pulse4_subtract = 0xA,
 		.pulse4_reverse = 0xA,
 		.byte_no = 3,
-		.dec_factor = 3,
-		.repeats_no = 32,
+		.dec_factor = 0,
+		.repeats_no = 1,
 		.adc_cycles = 1,
 	},
 	{
@@ -205,7 +212,7 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		},
 		.led1 = {
 			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_A,
+				.led_output_select = ADPD410X_OUTPUT_B,
 				.let_current_select = 0x00,
 			},
 		},
@@ -217,13 +224,13 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		},
 		.led3 = {
 			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_A,
+				.led_output_select = ADPD410X_OUTPUT_B,
 				.let_current_select = 0x00,
 			},
 		},
 		.led4 = {
 			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_A,
+				.led_output_select = ADPD410X_OUTPUT_B,
 				.let_current_select = 0x00,
 			},
 		},
@@ -236,8 +243,8 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		.pulse4_subtract = 0xA,
 		.pulse4_reverse = 0xA,
 		.byte_no = 3,
-		.dec_factor = 3,
-		.repeats_no = 32,
+		.dec_factor = 0,
+		.repeats_no = 1,
 		.adc_cycles = 1,
 	},
 	{
@@ -278,8 +285,8 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		.pulse4_subtract = 0xA,
 		.pulse4_reverse = 0xA,
 		.byte_no = 3,
-		.dec_factor = 3,
-		.repeats_no = 32,
+		.dec_factor = 0,
+		.repeats_no = 1,
 		.adc_cycles = 1,
 	},
 	{
@@ -302,48 +309,6 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		.led3 = {
 			.fields = {
 				.led_output_select = ADPD410X_OUTPUT_A,
-				.let_current_select = 0x30,
-			},
-		},
-		.led4 = {
-			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_B,
-				.let_current_select = 0x00,
-			},
-		},
-		.enable_ch2 = false,
-		.precon_option = ADPD410X_TIA_VREF,
-		.afe_trim_opt = ADPD410X_TIA_VREF_1V256,
-		.vref_pulse_opt = ADPD410X_TIA_VREF_1V256,
-		.chan2 = ADPD410X_TIA_VREF_50K,
-		.chan1 = ADPD410X_TIA_VREF_100K,
-		.pulse4_subtract = 0xA,
-		.pulse4_reverse = 0xA,
-		.byte_no = 3,
-		.dec_factor = 3,
-		.repeats_no = 32,
-		.adc_cycles = 1,
-	},
-	{
-		.ts_inputs = {
-			.option = ADPD410X_INaDIS_INbCH1,
-			.pair = ADPD410X_INP56,
-		},
-		.led1 = {
-			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_B,
-				.let_current_select = 0x00,
-			},
-		},
-		.led2 = {
-			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_B,
-				.let_current_select = 0x00,
-			},
-		},
-		.led3 = {
-			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_B,
 				.let_current_select = 0x40,
 			},
 		},
@@ -362,8 +327,50 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		.pulse4_subtract = 0xA,
 		.pulse4_reverse = 0xA,
 		.byte_no = 3,
-		.dec_factor = 3,
-		.repeats_no = 32,
+		.dec_factor = 0,
+		.repeats_no = 1,
+		.adc_cycles = 1,
+	},
+	{
+		.ts_inputs = {
+			.option = ADPD410X_INaDIS_INbCH1,
+			.pair = ADPD410X_INP56,
+		},
+		.led1 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led2 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led3 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x40,
+			},
+		},
+		.led4 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.enable_ch2 = false,
+		.precon_option = ADPD410X_TIA_VREF,
+		.afe_trim_opt = ADPD410X_TIA_VREF_1V256,
+		.vref_pulse_opt = ADPD410X_TIA_VREF_1V256,
+		.chan2 = ADPD410X_TIA_VREF_50K,
+		.chan1 = ADPD410X_TIA_VREF_100K,
+		.pulse4_subtract = 0xA,
+		.pulse4_reverse = 0xA,
+		.byte_no = 3,
+		.dec_factor = 0,
+		.repeats_no = 1,
 		.adc_cycles = 1,
 	},
 	{
@@ -404,8 +411,8 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		.pulse4_subtract = 0xA,
 		.pulse4_reverse = 0xA,
 		.byte_no = 3,
-		.dec_factor = 3,
-		.repeats_no = 32,
+		.dec_factor = 0,
+		.repeats_no = 1,
 		.adc_cycles = 1,
 	},
 	{
@@ -415,19 +422,19 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		},
 		.led1 = {
 			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_B,
+				.led_output_select = ADPD410X_OUTPUT_A,
 				.let_current_select = 0x00,
 			},
 		},
 		.led2 = {
 			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_B,
+				.led_output_select = ADPD410X_OUTPUT_A,
 				.let_current_select = 0x00,
 			},
 		},
 		.led3 = {
 			.fields = {
-				.led_output_select = ADPD410X_OUTPUT_B,
+				.led_output_select = ADPD410X_OUTPUT_A,
 				.let_current_select = 0x00,
 			},
 		},
@@ -446,23 +453,16 @@ static struct adpd410x_timeslot_init ts_init_tab[] = {
 		.pulse4_subtract = 0xA,
 		.pulse4_reverse = 0xA,
 		.byte_no = 3,
-		.dec_factor = 3,
-		.repeats_no = 32,
+		.dec_factor = 0,
+		.repeats_no = 1,
 		.adc_cycles = 1,
 	},
-
 };
 
 /* Register Configuration (address + data) */
-uint16_t reg_config_default[47][2] = {
+uint16_t reg_config_default[31][2] = {
 	/** General configuration */
-	{0x000f, 0x8000},
-	{0x000f, 0x0006},
-	{0x0000, 0x0048},
-	{0x0001, 0x000f},
-	{0x000d, 0x4e20},
-	{0x000e, 0x0000},
-	{0x0010, 0x0700},
+	{0x0001, 0x000F},
 
 	/** AFE Path */
 	{0x0101, 0x40DA},
@@ -474,16 +474,6 @@ uint16_t reg_config_default[47][2] = {
 	{0x01C1, 0x40DA},
 	{0x01E1, 0x40DA},
 
-	/** 2us LED pulse with 32us offset */
-	{0x0109, 0x0220},
-	{0x0129, 0x0220},
-	{0x0149, 0x0220},
-	{0x0169, 0x0220},
-	{0x0189, 0x0220},
-	{0x01A9, 0x0220},
-	{0x01C9, 0x0220},
-	{0x01E9, 0x0220},
-
 	/** 3us AFE width double sided */
 	{0x010A, 0x0003},
 	{0x012A, 0x0003},
@@ -493,16 +483,6 @@ uint16_t reg_config_default[47][2] = {
 	{0x01AA, 0x0003},
 	{0x01CA, 0x0003},
 	{0x01EA, 0x0003},
-
-	/** ~32us integrator offset to line up zero crossing of BPF */
-	{0x010B, 0x03FC},
-	{0x012B, 0x03FC},
-	{0x014B, 0x03FC},
-	{0x016B, 0x03FC},
-	{0x018B, 0x03FC},
-	{0x01AB, 0x03FC},
-	{0x01CB, 0x03FC},
-	{0x01EB, 0x03FC},
 
 	/** 2048 digital offset */
 	{0x010F, 0x8000},
@@ -514,5 +494,204 @@ uint16_t reg_config_default[47][2] = {
 	{0x01CF, 0x8000},
 	{0x01EF, 0x8000},
 };
+
+#else
+/* Timeslots Configuration */
+static struct adpd410x_timeslot_init ts_init_tab[] = {
+	{
+		.ts_inputs = {
+			.option = ADPD410X_INaCH1_INbCH2,
+			.pair = ADPD410X_INP12,
+		},
+		.led1 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x40,
+			},
+		},
+		.led2 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x40,
+			},
+		},
+		.led3 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x00,
+			},
+		},
+		.led4 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x00,
+			},
+		},
+		.enable_ch2 = true,
+		.precon_option = ADPD410X_VC1,
+		.afe_trim_opt = ADPD410X_TIA_VREF_0V8855,
+		.vref_pulse_opt = ADPD410X_TIA_VREF_0V8855,
+		.chan2 = ADPD410X_TIA_VREF_50K,
+		.chan1 = ADPD410X_TIA_VREF_50K,
+		.pulse4_subtract = 0xA,
+		.pulse4_reverse = 0xA,
+		.byte_no = 4,
+		.dec_factor = 0,
+		.repeats_no = 32,
+		.adc_cycles = 1,
+	},
+	{
+		.ts_inputs = {
+			.option = ADPD410X_INaCH1_INbCH2,
+			.pair = ADPD410X_INP34,
+		},
+		.led1 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x00,
+			},
+		},
+		.led2 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x00,
+			},
+		},
+		.led3 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x40,
+			},
+		},
+		.led4 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x40,
+			},
+		},
+		.enable_ch2 = true,
+		.precon_option = ADPD410X_TIA_VREF,
+		.afe_trim_opt = ADPD410X_TIA_VREF_1V256,
+		.vref_pulse_opt = ADPD410X_TIA_VREF_1V256,
+		.chan2 = ADPD410X_TIA_VREF_50K,
+		.chan1 = ADPD410X_TIA_VREF_100K,
+		.pulse4_subtract = 0xA,
+		.pulse4_reverse = 0xA,
+		.byte_no = 3,
+		.dec_factor = 0,
+		.repeats_no = 1,
+		.adc_cycles = 1,
+	},
+	{
+		.ts_inputs = {
+			.option = ADPD410X_INaCH1_INbCH2,
+			.pair = ADPD410X_INP56,
+		},
+		.led1 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x40,
+			},
+		},
+		.led2 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x40,
+			},
+		},
+		.led3 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led4 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.enable_ch2 = true,
+		.precon_option = ADPD410X_TIA_VREF,
+		.afe_trim_opt = ADPD410X_TIA_VREF_1V256,
+		.vref_pulse_opt = ADPD410X_TIA_VREF_1V256,
+		.chan2 = ADPD410X_TIA_VREF_50K,
+		.chan1 = ADPD410X_TIA_VREF_100K,
+		.pulse4_subtract = 0xA,
+		.pulse4_reverse = 0xA,
+		.byte_no = 3,
+		.dec_factor = 0,
+		.repeats_no = 1,
+		.adc_cycles = 1,
+	},
+	{
+		.ts_inputs = {
+			.option = ADPD410X_INaCH1_INbCH2,
+			.pair = ADPD410X_INP78,
+		},
+		.led1 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led2 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_A,
+				.let_current_select = 0x00,
+			},
+		},
+		.led3 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x40,
+			},
+		},
+		.led4 = {
+			.fields = {
+				.led_output_select = ADPD410X_OUTPUT_B,
+				.let_current_select = 0x40,
+			},
+		},
+		.enable_ch2 = true,
+		.precon_option = ADPD410X_TIA_VREF,
+		.afe_trim_opt = ADPD410X_TIA_VREF_1V256,
+		.vref_pulse_opt = ADPD410X_TIA_VREF_1V256,
+		.chan2 = ADPD410X_TIA_VREF_50K,
+		.chan1 = ADPD410X_TIA_VREF_100K,
+		.pulse4_subtract = 0xA,
+		.pulse4_reverse = 0xA,
+		.byte_no = 3,
+		.dec_factor = 0,
+		.repeats_no = 1,
+		.adc_cycles = 1,
+	},
+};
+
+/* Register Configuration (address + data) */
+uint16_t reg_config_default[13][2] = {
+	/** General configuration */
+	{0x0001, 0x000F},
+
+	/** AFE Path */
+	{0x0101, 0x40DA},
+	{0x0121, 0x40DA},
+	{0x0141, 0x40DA},
+	{0x0161, 0x40DA},
+
+	/** 3us AFE width double sided */
+	{0x010A, 0x0003},
+	{0x012A, 0x0003},
+	{0x014A, 0x0003},
+	{0x016A, 0x0003},
+
+	/** 2048 digital offset */
+	{0x010F, 0x8000},
+	{0x012F, 0x8000},
+	{0x014F, 0x8000},
+	{0x016F, 0x8000},
+};
+
+#endif
 
 #endif /* CN0567_CONFIG_H_ */


### PR DESCRIPTION
Add support for multiple timeslot configurations, one default and one
for the waterquality demo.

Update *.json file to create separate hex files for each configuration.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>