### PR TITLE
Incorrect unpacking of data for CN0429

### DIFF
--- a/projects/ADuCM3029_demo_cn0428_cn0429/src/adi_m355_gas_sensor.cpp
+++ b/projects/ADuCM3029_demo_cn0428_cn0429/src/adi_m355_gas_sensor.cpp
@@ -253,8 +253,8 @@ SENSOR_RESULT M355_GAS::SetI2CAddr(uint8_t new_I2C_address)
  * @details This command provides temperature information in signed 16bit format
  * 		which is used for sensor temperature compensation. The data is
  * 		transmitted in integer format * 100:
- *  		For example,	0x09E4 =>	2532 / 100 =>	+25.32ºC
- *  				0xFB50 =>	-1200 / 100 =>	-12ºC
+ *  		For example,	0x09E4 =>	2532 / 100 =>	+25.32ï¿½C
+ *  				0xFB50 =>	-1200 / 100 =>	-12ï¿½C
  */
 SENSOR_RESULT M355_GAS::ReadTemperature(int16_t *pSensData)
 {
@@ -781,7 +781,7 @@ SENSOR_RESULT M355_GAS::ReadDataPPB(int32_t *pSensData)
 	SENSOR_RESULT Result = this->I2CReadWrite(READ, READ_AVG_PPB, pBuff, 4);
 	delay_ms(50);
 	Result = this->I2CReadWrite(READ, READ_AVG_PPB, pBuff, 4);
-	val = (pBuff[0] << 24) | (pBuff[1] << 16) | (pBuff[2] << 8) | pBuff[3];
+	val = (pBuff[0] << 16) | (pBuff[1] << 8) | pBuff[2];
 
 	*pSensData = val;
 


### PR DESCRIPTION
CN0429 packs 3 bytes of data instead of 4. Edited the unpacking in ReadDataPPB function to accommodate 3 bytes instead of 4:
result_array[command_data.cmd_index][0] = (signed int)Sensor_Results.avg_ppb >> 16;
result_array[command_data.cmd_index][1] = (signed int)Sensor_Results.avg_ppb >> 8;
result_array[command_data.cmd_index][2] = (signed int)Sensor_Results.avg_ppb & 0xFF;