### PR TITLE
Fix for CN0418 Demo software unresponsive

### DIFF
--- a/projects/ADuCM3029_demo_cn0418/src/platform_drivers.c
+++ b/projects/ADuCM3029_demo_cn0418/src/platform_drivers.c
@@ -932,6 +932,8 @@ static int32_t usr_uart_read_nonblock(struct uart_desc *desc, uint8_t *data,
 	uint32_t error;
 	bool rx_done;
 	int32_t ret;
+	uint8_t c;
+	uint8_t *p = &c;
 
 	if(!desc->has_callback) {
 		ret = adi_uart_IsRxBufferAvailable((ADI_UART_HANDLE const)h_uart_device,
@@ -942,8 +944,20 @@ static int32_t usr_uart_read_nonblock(struct uart_desc *desc, uint8_t *data,
 			return 0;
 		*rdy = 1;
 
-		return adi_uart_GetRxBuffer((ADI_UART_HANDLE const)h_uart_device,
-					    (void **)&data, &error);
+		ret =  adi_uart_GetRxBuffer((ADI_UART_HANDLE const)h_uart_device,
+					    (void **)&p, &error);
+		if(ret != ADI_UART_SUCCESS)
+			return ret;
+
+		*data = *p;
+		*rdy = 1;
+
+		ret = adi_uart_SubmitRxBuffer((ADI_UART_HANDLE const)h_uart_device, p, 1, false);
+		if (ret != ADI_UART_SUCCESS)
+		    return ret;
+
+		return 0;
+
 	} else {
 		if(uart_ping_flag == 2) {
 			*data = *ping_ptr;


### PR DESCRIPTION
Engineer Zone Link:
https://ez.analog.com/reference-designs/f/q-a/593847/cn0418-demo-software-unresponsive/568618

Root Cause Analysis:
Data pointer inside usr_uart_read_nonblock function incorrectly passed the address of data. No buffer is returned therefore no placeholder present.

Fix:
Declared a temporary local variable to store the character input received through UART before called by caller function and performed proper pointer management to prevent losing the expected data. Resubmitted the RX buffer after calling adi_uart_GetRxBuffer() to store incoming bytes.